### PR TITLE
fix(mirror): stop dropping input on fresh activation, surface osascript failures

### DIFF
--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1735,11 +1735,23 @@ async fn agent_input(
     // it frontmost up front; if that fails, report the drop instead of lying.
     #[cfg(target_os = "macos")]
     {
-        let delivered = tokio::task::spawn_blocking(|| {
-            crate::macos::ensure_mirroring_frontmost(std::time::Duration::from_millis(1200))
-        })
-        .await
-        .unwrap_or(false);
+        // 1200ms was shorter than this same activation path's own documented
+        // reality (input_bridge.rs: "the osascript activation path takes >2s
+        // on first use, so the default deadline is generous" — 4000ms there).
+        // A too-short preflight here meant the very first tap after a fresh
+        // install/permission-grant would be dropped as "could not bring
+        // frontmost" even though activation was still in flight, not actually
+        // denied (issue #29). Match the injector's default so both paths give
+        // activation the same runway; still overridable for tight loops.
+        let front_deadline = std::env::var("PHONE_REMOTE_FRONT_DEADLINE_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(std::time::Duration::from_millis)
+            .unwrap_or(std::time::Duration::from_millis(4000));
+        let delivered =
+            tokio::task::spawn_blocking(move || crate::macos::ensure_mirroring_frontmost(front_deadline))
+                .await
+                .unwrap_or(false);
         if !delivered {
             return with_security_headers(
                 Response::builder()

--- a/crates/server/src/macos.rs
+++ b/crates/server/src/macos.rs
@@ -79,25 +79,47 @@ mod imp {
         // works: the Apple Event asks the TARGET app to activate itself, which
         // the system permits. First use pops an Automation consent once
         // ("iPhoneUse" wants to control "iPhone Mirroring") — grant it once.
+        //
+        // We capture stderr/exit code here (previously discarded via
+        // `.status()`) because a TCC/Automation denial fails *silently* from
+        // the caller's point of view otherwise: `osascript` prints
+        // "execution error: Not authorized to send Apple events to iPhone
+        // Mirroring. (-1743)" and exits non-zero, but with only `.status()`
+        // that reason never reaches the logs — every failure looks identical
+        // ("could not bring frontmost") whether the app quit, the name is
+        // localized differently, or Automation consent was denied. Surfacing
+        // it turns an unreproducible report into an actionable one (issue #29).
         for name in MIRRORING_NAMES {
-            let status = std::process::Command::new("/usr/bin/osascript")
+            match std::process::Command::new("/usr/bin/osascript")
                 .args(["-e", &format!(r#"tell application "{name}" to activate"#)])
-                .status();
-            if matches!(status, Ok(s) if s.success()) {
-                return;
+                .output()
+            {
+                Ok(out) if out.status.success() => return,
+                Ok(out) => tracing::warn!(
+                    "osascript activate {name:?} failed (exit {:?}): {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ),
+                Err(e) => tracing::warn!("osascript activate {name:?} could not run: {e}"),
             }
         }
         // Fallback (helps when Automation consent was denied): open -a still
         // works when the user isn't actively focused elsewhere.
         for name in MIRRORING_NAMES {
-            let status = std::process::Command::new("/usr/bin/open")
+            match std::process::Command::new("/usr/bin/open")
                 .args(["-a", name])
-                .status();
-            if matches!(status, Ok(s) if s.success()) {
-                return;
+                .output()
+            {
+                Ok(out) if out.status.success() => return,
+                Ok(out) => tracing::warn!(
+                    "open -a {name:?} failed (exit {:?}): {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ),
+                Err(e) => tracing::warn!("open -a {name:?} could not run: {e}"),
             }
         }
-        tracing::debug!("could not bring iPhone Mirroring frontmost via osascript or `open -a`");
+        tracing::warn!("could not bring iPhone Mirroring frontmost via osascript or `open -a`");
     }
 
     /// The known localized names of the iPhone Mirroring app (en + zh-CN).


### PR DESCRIPTION
Fixes/addresses #29.

## What was happening

Driving the phone in mirror mode from an agent session, `/agent/input` consistently returned `dropped:true` with `human_active:true` — even though I verified via `osascript -e 'tell application "System Events" to name of first process whose frontmost is true'` (and a full-desktop screenshot) that iPhone Mirroring genuinely *was* frontmost at the time of the call.

## Root causes found

1. **`http.rs`**: the `POST /agent/input` preflight calls `ensure_mirroring_frontmost()` with a **1200ms** deadline. But `input_bridge.rs`'s own injector loop uses a 4000ms default for the exact same activation path, with this comment already in the codebase: *"the osascript activation path takes >2s on first use, so the default deadline is generous."* The preflight was giving activation less than a third of the runway the code's own docs say it needs — so a fresh/slow activation was dropped as a false "human is using the Mac," even with nobody contending for the Mac.

2. **`macos.rs`**: `bring_mirroring_frontmost()` used `Command::status()` for both the `osascript` and `open -a` attempts, discarding stderr and the exit code entirely. A TCC/Automation consent denial (`osascript` exits non-zero with `"Not authorized to send Apple events to iPhone Mirroring. (-1743)"` on stderr) was therefore indistinguishable from "app not running," "name localized differently," or anything else — every failure collapsed into the same generic debug-level message. This made the original issue much harder to diagnose than it needed to be.

## Fix

- Bump the `http.rs` preflight deadline to 4000ms by default, matching the injector, and make it overridable via the existing `PHONE_REMOTE_FRONT_DEADLINE_MS` env var (previously only read by `input_bridge.rs`).
- Switch `bring_mirroring_frontmost()` to `Command::output()` and log the actual exit code + stderr at `warn` level for every activation attempt.

## Verification (real hardware)

Before the patch: `/agent/input` reliably dropped with `human_active:true` regardless of confirmed frontmost state.

After rebuilding with the patch (macOS 26.5.1, daemon 0.4.12 + this patch): `/agent/status` correctly reports `human_active:false`, `drivable:true`, `mirror_state:"active"`, and `shortcut home` / `shortcut spotlight` both land — confirmed via `/agent/screenshot` showing Spotlight genuinely open on the phone.

(Separately hit and fixed an unrelated environment issue on my end: a full disk had silently corrupted the release binary during the debug-symbol-strip step — `cargo build` reported success while writing a 16-byte binary. Not an iphone-use bug, just noting it in case it helps anyone else hitting a mysteriously-non-functional daemon after a build.)

---
*Opened by an AI agent (Claude Code) on behalf of the repo owner, who reviewed and approved filing this PR.*