### PR TITLE
fix(wda): send named keys as real key events, not literal text

### DIFF
--- a/crates/server/src/wda.rs
+++ b/crates/server/src/wda.rs
@@ -640,6 +640,15 @@ impl WdaClient {
     /// private-use range.  Keeping the mapping here gives HTTP, MCP, and the web
     /// client one device-native implementation instead of falling back to Mac
     /// keyboard events.
+    ///
+    /// Dispatched through the W3C Actions API (`POST /session/<id>/actions`)
+    /// with a **key input source**, NOT through [`Self::keys`]. `/wda/keys`
+    /// bottoms out in `FBKeyboard typeText:`, which is literal text entry: it
+    /// never interprets the private-use code points, so it *typed* them into the
+    /// focused field while WDA still answered `{"ok":true}` (issue #42 —
+    /// `return` left the search unsubmitted, `delete` made the text longer).
+    /// Only the Actions key source translates `\u{E007}` &co. into real key
+    /// events. Plain text keeps using [`Self::keys`], which is correct for it.
     pub async fn named_key(&mut self, name: &str) -> Result<()> {
         let value = match name {
             "return" | "enter" => "\u{E007}",
@@ -653,7 +662,25 @@ impl WdaClient {
             "down" => "\u{E015}",
             _ => anyhow::bail!("unsupported named key: {name}"),
         };
-        self.keys(value).await
+        let sid = self.ensure_session().await?.to_string();
+        let response = self
+            .http
+            .post(format!("{}/session/{}/actions", self.base, sid))
+            .json(&serde_json::json!({
+                "actions": [{
+                    "type": "key",
+                    "id": "keyboard",
+                    "actions": [
+                        { "type": "keyDown", "value": value },
+                        { "type": "keyUp",   "value": value }
+                    ]
+                }]
+            }))
+            .send()
+            .await
+            .context("POST /actions (key)")?;
+        ensure_wda_success(response, "POST /actions").await?;
+        Ok(())
     }
 
     /// Dismiss the on-screen keyboard so it stops covering a web page's own
@@ -1186,6 +1213,42 @@ mod tests {
 
         assert!(error.contains("invalid session id"), "{error}");
         assert!(error.contains("response lost"), "{error}");
+    }
+
+    #[test]
+    fn named_key_uses_actions_key_source_not_wda_keys() {
+        // issue #42: /wda/keys goes through `FBKeyboard typeText:`, which typed
+        // the private-use code point into the field instead of pressing the key.
+        // Only a key input source on /actions produces a real key event.
+        let (base, server) = mock_wda(1, |request| {
+            assert!(
+                request.starts_with("POST /session/SESSION/actions "),
+                "{request}"
+            );
+            assert!(!request.contains("/wda/keys"), "{request}");
+            assert!(request.contains(r#""type":"key""#), "{request}");
+            assert!(request.contains(r#""id":"keyboard""#), "{request}");
+            assert!(request.contains(r#""keyDown""#), "{request}");
+            assert!(request.contains(r#""keyUp""#), "{request}");
+            // U+E007 (WebDriver "Enter") travels as raw UTF-8 in the JSON body.
+            assert!(request.contains('\u{E007}'), "{request}");
+            r#"{"value":null}"#.to_string()
+        });
+        let mut client = WdaClient::new(base).unwrap();
+        client.session = Some("SESSION".to_string());
+
+        let sent = block(client.named_key("return"));
+        server.join().unwrap();
+        sent.unwrap();
+    }
+
+    #[test]
+    fn named_key_rejects_unsupported_name() {
+        let mut client = WdaClient::new("http://127.0.0.1:1".to_string()).unwrap();
+        client.session = Some("SESSION".to_string());
+
+        let error = block(client.named_key("f13")).unwrap_err().to_string();
+        assert!(error.contains("unsupported named key: f13"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

`{"type":"key","name":"return"}` and `{"type":"key","name":"delete"}` do not press
anything. The WebDriver private-use code point is inserted into the focused text
field as a literal character, and the daemon still answers
`{"ok":true,"transport":"wda"}`.

Reproduced from a Spotlight search field:

| Request | Response | Field value after |
|---|---|---|
| `{"type":"text","text":"abc"}` | `{"ok":true}` | `'abc'` |
| `{"type":"key","name":"return"}` | `{"ok":true}` | `'abc'` — search NOT submitted |
| `{"type":"key","name":"delete"}` | `{"ok":true}` | `'abc'` — backspace made the text longer |

## Root cause

`named_key()` mapped the name to its private-use code point and then called
`keys()`, which posts to `/wda/keys` — a route WebDriverAgent implements with
`FBKeyboard typeText:`, literal text entry that never interprets keycodes. Only
the W3C Actions key input source turns `\u{E007}` &co. into real key events.

## What changed

`crates/server/src/wda.rs`:

- `named_key()` now dispatches through `POST /session/<id>/actions` with a key
  input source (`keyDown` / `keyUp` on the code point), the same endpoint
  `tap_point()`, `longpress_point()`, `drag()`, and `swipe()` already use — and
  the same `ensure_wda_success()` check, so a W3C error envelope inside an HTTP
  200 still fails the call instead of being reported as `ok`.
- Its doc comment now records why it must not use `/wda/keys`.
- `keys()` is untouched: plain `{"type":"text"}` input is literal text, which is
  precisely what `/wda/keys` is for (and how CJK lands cleanly). The name → code
  point table (return/enter, escape, space, tab, delete/backspace, four arrows)
  and the `bail!` on an unsupported name are unchanged.
- Two unit tests on the existing `mock_wda` harness: one asserts the request goes
  to `/actions` with a key input source carrying U+E007 and never touches
  `/wda/keys`; one holds the unsupported-name error path.

## Verification

- `cargo check -p server` — clean.
- `cargo test -p server --lib named_key` — 2 passed.
- `cargo clippy -p server --all-targets` — no new warnings (the remaining ones are
  pre-existing, in `core`).

**On-device confirmation is still pending** — this is compile- and unit-verified
only; the fix has not been re-run against a real iPhone.

Fixes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebDriver key handling by using the standard Actions API.
  * Enter and other supported named keys now produce more reliable key press and release events.
  * Unsupported key names are rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->