### PR TITLE
fix(wda): opt-in bounded snapshots (#44); feat(mcp): --label for ps attribution (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ the heaviest users make the product better.
 | `PHONE_REMOTE_WDA_URL` | `http://127.0.0.1:8100` in direct installs | WDA control loopback. WDA itself has no authentication; direct input fails closed when this endpoint is unavailable. |
 | `PHONE_REMOTE_WDA_MJPEG_URL` | `http://127.0.0.1:9100` in direct installs | WDA MJPEG loopback. WDA itself has no authentication; the daemon exposes it to authenticated viewers at `/agent/mjpeg`. |
 | `PHONE_REMOTE_WDA_MANAGED` | on for Direct loopback endpoints | Whether this daemon owns the local WDA supervisor/relay lifecycle. Remote endpoints must be externally managed. |
+| `PHONE_REMOTE_WDA_SNAPSHOT_MAX_DEPTH` | *(unset — WDA default 50)* | Opt-in bound on WDA's accessibility snapshot depth (`snapshotMaxDepth`), applied once per WDA session. Try `20`–`30` if an app with an enormous tree (e.g. KakaoTalk, issue #44) kills the runner during `/agent/elements`. |
+| `PHONE_REMOTE_WDA_SNAPSHOT_TIMEOUT_S` | *(unset — WDA default 15)* | Opt-in bound on WDA's snapshot resolution time in seconds (`customSnapshotTimeout`), so an oversized snapshot fails that one request instead of wedging until testmanagerd kills the runner. |
 | `PHONE_REMOTE_IDLE_RELEASE_SECS` | `300` | After this many seconds without agent activity or a live viewer, stop the WDA runner so the phone is free for hands-on use. Reconnect starts it again; unlock the phone if required. Set `0` to keep WDA running. |
 | `PHONE_REMOTE_CF_TURN_KEY_ID` / `_API_TOKEN` | — | Legacy mirror/WebRTC Cloudflare TURN credentials. Not used by the direct MJPEG path. |
 | `PHONE_REMOTE_TURN_URLS` / `_USERNAME` / `_CREDENTIAL` | — | Legacy mirror/WebRTC static TURN credentials. |

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -56,6 +56,12 @@ cargo build --release -p iphone-use-mcp
 }
 ```
 
+**Telling resident processes apart** (issue #46): with several agent sessions
+open, `ps` shows many identical `iphone-use-mcp` rows. Add an optional
+`"args": ["--label", "my-project"]` to the server entry — the tag is ignored
+functionally but appears in `ps`/Activity Monitor argv, so each process is
+attributable to its session or project.
+
 ### Claude Code (project `.claude/settings.json` or `~/.claude/settings.json`)
 
 ```json

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -29,6 +29,12 @@ mod types;
     about = "MCP bridge and deterministic flow runner for iphone-use"
 )]
 struct Cli {
+    /// Free-form identity tag shown in `ps` output (issue #46). The server
+    /// ignores the value; passing e.g. `--label my-project` from your MCP
+    /// client config makes each of many otherwise-identical resident
+    /// `iphone-use-mcp` processes attributable to its session/project.
+    #[arg(long, value_name = "TAG")]
+    label: Option<String>,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -83,7 +89,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Build the daemon client from env.
     let daemon = client::DaemonClient::from_env();
-    tracing::info!(url = %daemon.base_url(), "iphone-use-mcp starting");
+    tracing::info!(
+        url = %daemon.base_url(),
+        label = cli.label.as_deref().unwrap_or(""),
+        "iphone-use-mcp starting"
+    );
 
     // Run until the MCP client closes the pipe.
     let handler = server::PhoneHandler::new(daemon);

--- a/crates/server/src/wda.rs
+++ b/crates/server/src/wda.rs
@@ -151,6 +151,36 @@ impl WdaClient {
                 .await
                 .context("POST /session body")?;
             self.session = Some(parse_session_id(&text)?);
+            // Opt-in bounded-snapshot settings (issue #44): apps with an
+            // enormous accessibility tree (hardware-reported with KakaoTalk)
+            // can make WDA's hierarchy snapshot run so long that testmanagerd
+            // kills the whole runner (`** BUILD INTERRUPTED **`) and the
+            // device goes blocked. WDA's `snapshotMaxDepth` /
+            // `customSnapshotTimeout` settings live in its process-global
+            // configuration, so applying them once per session also bounds the
+            // session-less `/source` reads behind `/agent/elements`. Off by
+            // default — behavior is byte-identical unless the operator sets
+            // the env vars. Best-effort: a failure to apply must not take
+            // down session creation.
+            if let Some(settings) = snapshot_settings_from_env() {
+                let sid = self.session.as_deref().unwrap().to_string();
+                let result = self
+                    .http
+                    .post(format!("{}/session/{}/appium/settings", self.base, sid))
+                    .json(&serde_json::json!({ "settings": settings }))
+                    .send()
+                    .await;
+                match result {
+                    Ok(response) => {
+                        if let Err(error) =
+                            ensure_wda_success(response, "POST /appium/settings (snapshot)").await
+                        {
+                            tracing::warn!("apply WDA snapshot settings: {error:#}");
+                        }
+                    }
+                    Err(error) => tracing::warn!("apply WDA snapshot settings: {error:#}"),
+                }
+            }
         }
         Ok(self.session.as_deref().unwrap())
     }
@@ -841,6 +871,31 @@ impl WdaClient {
         ensure_wda_success(response, "POST wda/lock").await?;
         Ok(())
     }
+}
+
+/// Bounded-snapshot WDA settings from the environment (issue #44), applied
+/// once per created session. `PHONE_REMOTE_WDA_SNAPSHOT_MAX_DEPTH` maps to
+/// WDA's `snapshotMaxDepth` (tree levels; WDA's own default is 50) and
+/// `PHONE_REMOTE_WDA_SNAPSHOT_TIMEOUT_S` to `customSnapshotTimeout` (seconds;
+/// WDA's default 15). Unset or unparseable values are simply omitted, so the
+/// default daemon applies no settings at all.
+fn snapshot_settings_from_env() -> Option<serde_json::Map<String, serde_json::Value>> {
+    let mut settings = serde_json::Map::new();
+    if let Some(depth) = std::env::var("PHONE_REMOTE_WDA_SNAPSHOT_MAX_DEPTH")
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .filter(|depth| *depth > 0)
+    {
+        settings.insert("snapshotMaxDepth".to_string(), depth.into());
+    }
+    if let Some(timeout) = std::env::var("PHONE_REMOTE_WDA_SNAPSHOT_TIMEOUT_S")
+        .ok()
+        .and_then(|value| value.trim().parse::<f64>().ok())
+        .filter(|timeout| timeout.is_finite() && *timeout > 0.0)
+    {
+        settings.insert("customSnapshotTimeout".to_string(), timeout.into());
+    }
+    (!settings.is_empty()).then_some(settings)
 }
 
 /// One row of the flattened element tree.


### PR DESCRIPTION
Two small issue-driven changes, both zero-impact by default:

**#44 (KakaoTalk a11y snapshot kills the WDA runner)** — new opt-in env vars `PHONE_REMOTE_WDA_SNAPSHOT_MAX_DEPTH` (WDA `snapshotMaxDepth`, its default is 50) and `PHONE_REMOTE_WDA_SNAPSHOT_TIMEOUT_S` (WDA `customSnapshotTimeout`, default 15s), applied best-effort once per created session. WDA stores these in process-global configuration, so they also bound the session-less `/source` reads behind `/agent/elements`. Unset → no settings call at all, byte-identical behavior. Needs confirmation from the #44 reporter (we have no KakaoTalk repro device); documented in the README env table.

**#46 (13 identical `iphone-use-mcp` rows in ps)** — `iphone-use-mcp --label <TAG>`: functionally ignored, shows in `ps`/Activity Monitor argv, logged at startup. Documented in `crates/mcp/README.md`.

Tests: server 233 + mcp 41 all green; clippy clean for both crates; fmt clean.

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU