### PR TITLE
fix(status): surface a signed-out Xcode as setup_blocked_on:"account"

### DIFF
--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1680,6 +1680,14 @@ fn parse_setup_log_blocked_on(txt: &str) -> String {
         || latest_attempt.contains("no USB iPhone is connected")
     {
         "usb".to_string()
+    } else if latest_attempt.contains("has no signed-in Apple account")
+        || latest_attempt.contains("No Accounts:")
+        || latest_attempt.contains("could not find or create the WDA development provisioning")
+    {
+        // A signed-out Xcode (common after an Xcode update) fails every WDA
+        // build with "No Accounts"; surfacing it beats a generic wda blocker
+        // that sends the operator to a log they may not know exists.
+        "account".to_string()
     } else {
         String::new()
     }
@@ -1702,6 +1710,9 @@ fn setup_blocker_hint(blocked_on: &str) -> Option<&'static str> {
         "ddi" => Some(
             "the iPhone Developer Disk Image is unavailable — open Xcode with the phone connected, let device preparation finish, then poll status",
         ),
+        "account" => Some(
+            "Xcode has no usable signed-in Apple account or WDA provisioning profile — open Xcode → Settings → Accounts, sign in and select the development team, then poll status; the managed service retries automatically",
+        ),
         "wda" => Some(
             "WebDriverAgent failed to start — inspect ~/.iphone-use/wda-agent.log and run setup-wda.sh doctor before retrying",
         ),
@@ -1723,7 +1734,7 @@ fn parse_setup_status(txt: &str, now: u64) -> Option<WdaSetupStatus> {
     }
     if !matches!(
         status.blocked_on.as_str(),
-        "" | "warp" | "proxy" | "usb" | "trust" | "ddi" | "wda"
+        "" | "warp" | "proxy" | "usb" | "trust" | "ddi" | "account" | "wda"
     ) {
         return None;
     }
@@ -6766,7 +6777,7 @@ mod tests {
 
     #[test]
     fn setup_status_accepts_every_setup_script_blocker() {
-        for blocker in ["warp", "proxy", "usb", "trust", "ddi", "wda"] {
+        for blocker in ["warp", "proxy", "usb", "trust", "ddi", "account", "wda"] {
             let payload = format!(r#"{{"blocked_on":"{blocker}","ts":1000}}"#);
             assert_eq!(parse_setup_blocked_on(&payload, 1100), blocker);
             assert!(
@@ -6780,6 +6791,22 @@ mod tests {
         assert!(setup_blocker_hint("warp")
             .unwrap()
             .contains("Traffic only mode"));
+        // A signed-out Xcode must send the operator to Accounts, not to a log.
+        assert!(setup_blocker_hint("account")
+            .unwrap()
+            .contains("Settings → Accounts"));
+    }
+
+    #[test]
+    fn setup_log_fallback_recognizes_signed_out_xcode_from_latest_attempt_only() {
+        let signed_out = "== Checking prerequisites\n\
+            ✓ Xcode: Xcode 26.6\n\
+            ✗ Xcode has no signed-in Apple account. Open Xcode → Settings → Accounts,\n";
+        assert_eq!(parse_setup_log_blocked_on(signed_out), "account");
+
+        // A later attempt that got past signing must clear the stale blocker.
+        let recovered = format!("{signed_out}== Checking prerequisites\n✓ Team: 43G3AR9DT8\n");
+        assert_eq!(parse_setup_log_blocked_on(&recovered), "");
     }
 
     // --- wda_died_reason (#26 §2) ------------------------------------------

--- a/scripts/setup-wda.sh
+++ b/scripts/setup-wda.sh
@@ -1897,13 +1897,13 @@ while [ -z "$PHONE_URL" ]; do
     # first used to hide the real account/profile error behind a generic
     # "runner exited" message.
     if grep -q "No Accounts:" "$RUN_LOG" 2>/dev/null; then
-        _setstatus signing-fail wda "sign in to an Apple account in Xcode"
+        _setstatus signing-fail account "sign in to an Apple account in Xcode"
         die "Xcode has no signed-in Apple account. Open Xcode → Settings → Accounts,
    sign in and select the development team, then rerun."
     fi
     if grep -q "No profiles for .* were found\|requires a provisioning profile" \
         "$RUN_LOG" 2>/dev/null; then
-        _setstatus signing-fail wda "Xcode could not create the WDA provisioning profile"
+        _setstatus signing-fail account "Xcode could not create the WDA provisioning profile"
         die "Xcode could not find or create the WDA development provisioning profile.
    In Xcode → Settings → Accounts, refresh the selected team, keep the iPhone
    registered, then rerun. If WARP is connected, its effective Excluded routes

--- a/skills/iphone-use/SKILL.md
+++ b/skills/iphone-use/SKILL.md
@@ -61,7 +61,7 @@ and is not a Direct readiness signal.
   build after an Xcode update can take several minutes. Never send input until
   `drivable:true`.
 - `device_state:"blocked"` or `"offline"` → read `hint` and
-  `setup_blocked_on` (`warp|proxy|usb|trust|ddi`) and fix that blocker first.
+  `setup_blocked_on` (`warp|proxy|usb|trust|ddi|account`) and fix that blocker first.
 - Never switch to `mode=mirror` as automatic recovery. Mirror is an explicit
   operator-selected compatibility mode.
 
@@ -181,7 +181,7 @@ documented or unit-tested action is not automatically a current-device proof:
   setup, and restart the daemon to switch devices. Never pass a one-off UDID
   during recovery.
 - **`mode=agent` stuck / `wda` stays false → read `status.setup_blocked_on`**
-  (`warp|proxy|usb|trust|ddi`). The #1 blocker is **`warp`**: Cloudflare WARP (or any
+  (`warp|proxy|usb|trust|ddi|account`). The #1 blocker is **`warp`**: Cloudflare WARP (or any
   VPN) wedges the CoreDevice tunnel xcodebuild needs when its effective Split
   Tunnel exclusions omit `fe80::/10` or the device RSD ULA range `fd00::/8`.
   If WARP is only needed for selected destinations, prefer **Traffic only** mode


### PR DESCRIPTION
Hardware-hit today: after an Xcode update signed the account out, every WDA rebuild failed with `No Accounts`, but `/agent/status` showed only `device_state:"blocked"` with the generic `wda` blocker ("inspect the log") — the actual cause was buried in `setup_message`, and the operator watched an unexplained `blocked` for minutes.

- `setup-wda.sh` emits `blocked_on:"account"` for the missing Apple account and the missing WDA provisioning profile (was: generic `wda`).
- Daemon whitelist accepts `account`; its status hint names the fix: Xcode → Settings → Accounts, sign in, select the team.
- Log-text fallback recognizes the signed-out signature from the latest attempt only (a later signed-in attempt clears it) — covers older helpers that don't write the structured status.
- SKILL.md blocker vocabulary now `warp|proxy|usb|trust|ddi|account`.

Tests: 234 server tests green (2 new); clippy/fmt clean.

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU