### PR TITLE
fix(wda): empty JSON body on element clear; sticky trust blocker through ddi-wait

### DIFF
--- a/crates/server/src/wda.rs
+++ b/crates/server/src/wda.rs
@@ -340,6 +340,10 @@ impl WdaClient {
                 "{}/session/{}/element/{}/clear",
                 self.base, sid, element_id
             ))
+            // A bodyless POST is rejected with 400 by current WDA builds
+            // (hardware-hit on 9.15.3 during the set_value("") validation);
+            // send the same empty JSON object every other element POST sends.
+            .json(&serde_json::json!({}))
             .send()
             .await
             .context("POST element/clear")?;
@@ -595,6 +599,8 @@ impl WdaClient {
                 "{}/session/{}/element/{}/clear",
                 self.base, sid, id
             ))
+            // Same bodyless-POST 400 as clear_element on current WDA builds.
+            .json(&serde_json::json!({}))
             .send()
             .await
             .context("POST /element/clear")?;

--- a/scripts/setup-wda.sh
+++ b/scripts/setup-wda.sh
@@ -1815,7 +1815,11 @@ fi
 # Pitfall: 'Developer Disk Image is not mounted' usually means the phone is
 # LOCKED or just-connected — not an Xcode version problem. Keep it unlocked.
 if [ "$WDA_ALLOW_LAN" = "1" ]; then
-    _setstatus ddi-wait "" "waiting for developer services — unlock and keep the iPhone awake"
+    # Carry the sticky trust blocker through this early phase too: clearing it
+    # here made status flip back to a generic "waiting for developer services"
+    # between failed attempts while the phone still needed the same manual
+    # trust approval (operator-reported: "who knows what we're waiting for").
+    _setstatus ddi-wait "$_BUILD_BLOCKER" "waiting for developer services — unlock and keep the iPhone awake"
     info "Waiting for developer services (UNLOCK the iPhone and keep it awake)"
 else
     _setstatus ddi-wait usb "waiting for developer services — unlock + USB"


### PR DESCRIPTION
Two fixes found during today's hardware validation of #47 (WDA 9.15.3, iPhone 17 Pro Max, iOS 27):

1. **`POST /element/:id/clear` 400s without a body** on current WDA builds — `set_value`'s clear-then-type silently degraded to append, and `set_value("")` failed with `outcome_unknown`. Both `clear_element` and the older `clear_active` (behind `text{clear:true}`) now send the empty JSON object every other element POST already sends. Note today's successful replace test may have worked via WDA's own value-set semantics; the clear path is now correct regardless. Hardware retest of `set_value("")` pending (phone disconnected).

2. **Sticky trust blocker gap**: on each retry, `setup-wda.sh` cleared the trust blocker when re-entering `ddi-wait`, so `/agent/status` flipped back to generic "waiting for developer services" while the phone still needed the same manual trust approval — the operator watched the loop with no idea what to do. The sticky blocker now survives `ddi-wait` like it already survives `building`; `serving` still clears it.

Tests: 234 server tests green; fmt/clippy clean.

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU