### PR TITLE
fix(agent): stale WDA element refs (404) fail as retryable element_not_found

### DIFF
--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -3172,6 +3172,16 @@ async fn resolve_snapshot_row_element(
     }
 }
 
+/// WDA answers 404 on `element/:id/*` routes when the resolved element
+/// reference went stale between lookup and use (live-updating UI such as
+/// Spotlight results churns references within milliseconds — hardware-hit
+/// 2026-09-01). A 404 proves the mutation was NOT dispatched, so callers may
+/// safely surface it as retryable element_not_found instead of a
+/// retry_safe:false unknown outcome.
+fn wda_error_is_missing_element(error: &anyhow::Error) -> bool {
+    format!("{error:#}").contains("404 Not Found")
+}
+
 async fn tap_snapshot_element(
     w: &mut crate::wda::WdaClient,
     value: &serde_json::Value,
@@ -3194,10 +3204,13 @@ async fn tap_snapshot_element(
             [element_id] => element_id,
             _ => return Err(SnapshotElementTapError::Ambiguous),
         };
-        return w
-            .click_element(element_id)
-            .await
-            .map_err(SnapshotElementTapError::AfterDispatch);
+        return w.click_element(element_id).await.map_err(|error| {
+            if wda_error_is_missing_element(&error) {
+                SnapshotElementTapError::NotFound
+            } else {
+                SnapshotElementTapError::AfterDispatch(error)
+            }
+        });
     }
 
     let (x, y) = element_center(row).ok_or(SnapshotElementTapError::Invalid)?;
@@ -3223,10 +3236,13 @@ async fn set_value_snapshot_element(
     let element_id = resolve_snapshot_row_element(w, &rows[index]).await?;
     if text.is_empty() {
         // Clearing IS the requested mutation — report its real outcome.
-        return w
-            .clear_element(&element_id)
-            .await
-            .map_err(SnapshotElementTapError::AfterDispatch);
+        return w.clear_element(&element_id).await.map_err(|error| {
+            if wda_error_is_missing_element(&error) {
+                SnapshotElementTapError::NotFound
+            } else {
+                SnapshotElementTapError::AfterDispatch(error)
+            }
+        });
     }
     // Clear-then-type is one intentional compound action (same contract as
     // `text` with `clear:true`): the clear is best-effort, the type is still
@@ -3234,9 +3250,13 @@ async fn set_value_snapshot_element(
     if let Err(error) = w.clear_element(&element_id).await {
         tracing::warn!("wda clear_element before set_value: {error:#}");
     }
-    w.type_into(&element_id, &text)
-        .await
-        .map_err(SnapshotElementTapError::AfterDispatch)
+    w.type_into(&element_id, &text).await.map_err(|error| {
+        if wda_error_is_missing_element(&error) {
+            SnapshotElementTapError::NotFound
+        } else {
+            SnapshotElementTapError::AfterDispatch(error)
+        }
+    })
 }
 
 /// Shared swipe-travel curve: how far a scroll gesture actually moves for a
@@ -3353,9 +3373,13 @@ async fn tap_unique_locator(
         [element_id] => element_id,
         _ => return Err(UniqueLabelTapError::Ambiguous),
     };
-    w.click_element(element_id)
-        .await
-        .map_err(UniqueLabelTapError::AfterDispatch)
+    w.click_element(element_id).await.map_err(|error| {
+        if wda_error_is_missing_element(&error) {
+            UniqueLabelTapError::NotFound
+        } else {
+            UniqueLabelTapError::AfterDispatch(error)
+        }
+    })
 }
 
 fn wda_predicate_literal(value: &str) -> String {


### PR DESCRIPTION
Found during today's hardware retest: on live-updating UIs (Spotlight results), a freshly resolved WDA element id can go stale between lookup and use — WDA answers **404** on `element/:id/click|clear|value`. That 404 proves nothing was dispatched, yet it surfaced as `outcome_unknown` + `retry_safe:false`, dead-ending well-behaved agents.

Now the missing-element 404 maps to `element_not_found` (`outcome:"not_sent"`, `retry_safe:true`) for snapshot-bound taps, locator taps, and `set_value` — callers refresh the tree and retry cheaply. Non-404 failures keep the conservative unknown-outcome semantics.

Hardware-validated (iPhone 17 Pro Max, iOS 27, WDA 9.15.3): consecutive `set_value` A→B against Spotlight now lands on the second client attempt (exact replace, no remnant), and `set_value("")` clears. Full battery today: T1 clear ✅ T2 A→B replace ✅ T3 nested-scroll containment ✅ (Weather hourly strip moves, outer page pixel-identical) T4 chained `?return=delta` ✅.

Tests: 234 server tests green; fmt clean.

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU