### PR TITLE
docs(research): paradigm explorations — semantic intents / visual fallback / action affordances

### DIFF
--- a/docs/research/2026-09-action-affordances.md
+++ b/docs/research/2026-09-action-affordances.md
@@ -1,0 +1,346 @@
+# Action affordances as first-class element data (`/agent/elements` + a generic `perform` action)
+
+Research doc, 2026-09. Investigates what WebDriverAgent (WDA) can expose per element
+beyond what `crates/server/src/wda.rs` parses today, and designs an additive, sparse
+way to surface each element's *available actions* plus a generic action to invoke them
+— inspired by the LUMOS pattern ([arXiv 2606.30697](https://arxiv.org/abs/2606.30697):
+accessibility metadata → machine-readable "semantic blueprints" with roles, values,
+bounds, **and action affordances**) and macOS open-computer-use's
+`perform_secondary_action` (macOS AX exposes `AXActionNames` per element; iOS does not,
+so affordances must be *derived*).
+
+All WDA findings below were verified against the actual pinned source
+(appium/WebDriverAgent **v9.15.3** tarball), not documentation. File references are to
+that tree.
+
+## 中文摘要
+
+调研结论：本仓库当前只解析了 WDA `/source?format=json` 每个节点字段的一个子集，而 v9.15.3
+的响应里**本来就带着** `traits`（无障碍特征串，含 `Adjustable`/`Selected`/`ToggleButton` 等）、
+`minValue`/`maxValue`（Slider/Stepper 专有）等字段——也就是说暴露"该元素支持哪些动作"
+不需要改 WDA、不增加任何设备端开销，只需在 `flatten_tree` 里多解析几个已经在 JSON 里的键。
+调用侧 WDA 已有成套的 element-scoped 手势路由（`/wda/element/:uuid/touchAndHold、doubleTap、
+pinch、rotate、forceTouch、scroll` 及 `/wda/pickerwheel/:uuid/select` 的 next/previous），
+可以承载一个通用的 `{"type":"perform","element":N,"snapshot":"…","action":"…"}` 动作，
+完全复用现有 snapshot-token 防陈旧机制和 fail-closed 错误分类。唯一拿不到的是
+`UIAccessibilityCustomAction`（自定义动作列表）：XCUITest 公开层和 WDA v9.15.3 源码里
+完全没有这条通路，需要 fork 打补丁且结果不确定。总体判定：**高度可行，核心零 fork**；
+建议先做一个 env-flag 后置的 traits/min/max 解析 spike（约半天到一天）。
+
+---
+
+## 1. Inventory: what WDA v9.15.3 actually exposes
+
+### 1.1 `/source?format=json` — per-node keys (the tree the daemon already fetches)
+
+Serializer: `XCUIApplication+FBHelpers.m`, `dictionaryForElement:recursive:excludedAttributes:`
+plus `fb_attributeBlockMapForWrappedSnapshot:`.
+
+Always emitted per node:
+
+| key | notes | parsed by `flatten_tree` today? |
+|---|---|---|
+| `type` | `XCUIElementType…` short name | yes (`kind`) |
+| `rawIdentifier` | accessibility identifier or null | yes (`identifier`) |
+| `name`, `label`, `value` | | yes |
+| `rect` | `{x,y,width,height}` dict | yes |
+| `frame` | `NSStringFromCGRect` **string** (`"{{x, y}, {w, h}}"`), infinite values clamped | no (redundant with `rect`) |
+| `nativeFrame` | raw rendered frame, string | no |
+| `isEnabled` / `isVisible` / `isAccessible` / `isFocused` | `"0"`/`"1"` strings | yes |
+| **`traits`** | **comma-separated accessibility-trait names, e.g. `"Button, Selected"`** | **no — the key finding** |
+
+Conditionally emitted:
+
+| key | condition (`FBElementHelpers.m`) | parsed today? |
+|---|---|---|
+| `placeholderValue` | only TextView / TextField / SearchField / SecureTextField | yes |
+| **`minValue`**, **`maxValue`** | **only Slider and Stepper** (`FBDoesElementSupportMinMaxValue`), emitted as `NSNumber.stringValue` | **no** |
+
+So **every `/source` response the daemon already pays for carries `traits` and
+(for sliders/steppers) `minValue`/`maxValue`; the daemon currently throws them away.**
+Parsing them costs zero extra WDA traffic and zero extra snapshot time.
+
+`GET /source` also accepts `excluded_attributes=<comma-list>` (`FBDebugCommands.m:49`) —
+we could *exclude* `traits` for payload thrift, but not request anything extra; the set
+above is the ceiling for the JSON tree.
+
+### 1.2 The traits vocabulary (`FBAccessibilityTraits.m`)
+
+`traits` is the element's `UIAccessibilityTraits` bitmask rendered to names:
+
+`None, Button, Link, Header, SearchField, Image, Selected, PlaysSound, KeyboardKey,
+StaticText, SummaryElement, NotEnabled, UpdatesFrequently, StartsMediaSession,
+Adjustable, AllowsDirectInteraction, CausesPageTurn, TabBar` — plus, when WDA is built
+with Xcode 15+/clang 16 on iOS 17+ (true for this repo's local builds):
+`ToggleButton, SupportsZoom`.
+
+Affordance-relevant signal:
+
+- **`Adjustable`** — the element implements `accessibilityIncrement`/`accessibilityDecrement`.
+  This is the iOS-native "increment/decrement affordance" bit. It appears on sliders,
+  steppers, pickers, and **custom SwiftUI/UIKit adjustable controls that the element
+  tree otherwise shows as `Other`** — exactly the rows an agent currently can't
+  recognize as drivable.
+- **`Selected`** — selection state (tab bars, segmented controls, filter chips).
+  Today invisible in `/agent/elements`; `value` is usually empty for these.
+- **`ToggleButton`** (iOS 17+) — a button with on/off semantics that is *not* a
+  `Switch` in the tree.
+- **`Link`, `Header`, `TabBar`, `SummaryElement`** — structural semantics (useful for
+  locators, not actions).
+- `NotEnabled` duplicates `isEnabled:false`; `StaticText`/`Image`/`Button`/`SearchField`/
+  `KeyboardKey` mostly duplicate `type`. These should be filtered out, not re-emitted.
+
+### 1.3 What the tree does NOT carry (but per-element routes do)
+
+Available only via `GET /session/:sid/element/:uuid/attribute/:name` (any `wd*`
+property in `Routing/FBElement.h`) or a dedicated route, i.e. one HTTP round-trip
+per element after a find:
+
+- `selected` (`GET /element/:uuid/selected`) — but redundant: the `Selected` trait in
+  the tree carries the same bit for free.
+- `hittable` (`wdHittable`) — genuine "can a synthesized touch land here" signal;
+  **not** in the JSON tree at v9.15.3 (upstream has an `includeHittableInPageSource`
+  setting only in newer majors' XML path). N+1 cost — not worth bulk use.
+- `index` (`wdIndex`), `accessibilityContainer`.
+
+### 1.4 Per-element action routes (`FBElementCommands.m`, non-tvOS)
+
+Element-scoped (take an element UUID from a find; WDA computes the geometry — no
+rect math on our side, immune to the stale-rect problem `tap_snapshot_element`
+already defends against):
+
+| route | parameters | affordance |
+|---|---|---|
+| `POST /wda/element/:uuid/touchAndHold` | `duration` (s) | long-press → context menu ("secondary action") |
+| `POST /wda/element/:uuid/doubleTap` | — | double tap |
+| `POST /wda/element/:uuid/twoFingerTap` | — | two-finger tap |
+| `POST /wda/element/:uuid/tapWithNumberOfTaps` | `numberOfTaps`, `numberOfTouches` | n-tap/n-touch |
+| `POST /wda/element/:uuid/forceTouch` | `pressure?`, `duration?` | force press (peek/pop-era; niche) |
+| `POST /wda/element/:uuid/pinch` | `scale`, `velocity` | pinch zoom in/out |
+| `POST /wda/element/:uuid/rotate` | `rotation`, `velocity` | rotate |
+| `POST /wda/element/:uuid/swipe` | `direction` (`up/down/left/right`), `velocity?` | directional swipe inside the element |
+| `POST /wda/element/:uuid/scroll` | `direction`+`distance` \| `name` \| `predicateString` \| `toVisible` | scroll a container until a child is visible — a *semantic* scroll |
+| `POST /wda/element/:uuid/scrollTo` | — | scroll this element into view |
+| `POST /wda/element/:uuid/dragfromtoforduration` | `fromX/Y`,`toX/Y`,`duration` | element-relative drag |
+| `POST /wda/element/:uuid/pressAndDragWithVelocity` | `pressDuration`,`toElement`,`velocity`,`holdDuration` | long-press-drag onto another element (reorder!) |
+| `POST /wda/pickerwheel/:uuid/select` | `order` (`next`/`previous`), `offset?`, `value?`, `maxAttempts?` | **one-notch increment/decrement of a picker wheel** |
+| `POST /element/:uuid/value` (`handleSetValue`) | `value`/`text` | type into text inputs; **PickerWheel → `adjustToPickerWheelValue:`; Slider → `adjustToNormalizedSliderPosition:` with a required 0..1 value** |
+| `POST /element/:uuid/click`, `/clear` | | already used |
+
+Coordinate twins exist for most (`/wda/touchAndHold`, `/wda/doubleTap`,
+`/wda/pinch`, …) with optional `x`/`y`; without a session element they act on the
+active application's center. The repo's W3C `/actions` path already covers the
+coordinate cases it needs.
+
+Notable non-element extras: `POST /wda/pressButton` supports `home`, `volumeUp`,
+`volumeDown` (real devices), and `POST /wda/performIoHidEvent` takes an arbitrary
+HID `page`/`usage`/`duration` — a future "named hardware key" surface.
+
+Two accidental behaviors of today's code worth recording:
+
+1. `set_value` (which calls `type_into` → `POST element/:id/value`) **already**
+   adjusts a Slider if pointed at one — WDA interprets the string as a normalized
+   0..1 position — and adjusts a PickerWheel via `adjustToPickerWheelValue`. This is
+   undocumented, unvalidated (`set_value` never checks `kind`), and the reason a
+   formal `perform` should own the non-text cases.
+2. `increment`/`decrement` has **no single WDA primitive** except for picker wheels.
+   For a Stepper, the tree exposes its two child `Button`s (labels usually
+   "Increment"/"Decrement", localized); for a Slider, increment = read
+   `value`/`min`/`max`, compute, set. For a bare `Adjustable`-trait `Other` element
+   there is *no* reachable increment path (see §4).
+
+### 1.5 What does not exist at all in WDA v9.15.3
+
+- **`UIAccessibilityCustomAction`**: zero occurrences of `CustomAction` anywhere in
+  `WebDriverAgentLib`. No route lists them, no snapshot key carries them.
+- No route invokes `accessibilityIncrement`/`accessibilityDecrement` directly (XCUITest
+  only exposes them indirectly through `adjustToPickerWheelValue`/`adjustToNormalizedSliderPosition`).
+- No per-element "supported actions" query — iOS/XCUITest simply has no analogue of
+  macOS AX's `AXActionNames` or Windows UIA's control patterns. Affordances must be
+  **derived** from `type` + `traits` + `min/max`, which is precisely the design below.
+
+## 2. Design
+
+### 2.1 New sparse `ElementRow` fields (additive, `skip_serializing_if` like the rest)
+
+```rust
+/// Derived affordances beyond the universal tap/longpress, from type+traits+min/max.
+/// Emitted only when non-empty; plain Buttons/Cells/StaticText emit nothing.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub actions: Option<Vec<String>>,           // e.g. ["increment","decrement"]
+/// From the `Selected` accessibility trait; only `true` is emitted.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub selected: Option<bool>,
+/// Slider/Stepper range, parsed from WDA's minValue/maxValue strings.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub min: Option<f64>,
+#[serde(skip_serializing_if = "Option::is_none")]
+pub max: Option<f64>,
+```
+
+Derivation rules (daemon-side, in `flatten_tree`):
+
+| condition | emitted `actions` |
+|---|---|
+| `kind == "PickerWheel"` | `["increment","decrement","adjust"]` |
+| `kind == "Stepper"` (or both min/max present on non-slider) | `["increment","decrement"]` |
+| `kind == "Slider"` | `["increment","decrement","adjust"]` |
+| trait `Adjustable` on any other kind | `["increment","decrement"]` *(advisory — see §4 caveat)* |
+| `kind == "Switch"` or trait `ToggleButton` | `["toggle"]` |
+| trait `Selected` present | `selected: true` (state, not an action) |
+
+Deliberately **not** emitted: `tap`, `longpress`/`menu`, `double_tap`, swipe/scroll —
+universal to every hittable element, so listing them per row is pure payload bloat and
+regresses the lean-JSON contract. `perform` still accepts them (§2.2); `actions` is the
+*non-default* affordance list, not an exhaustive one.
+
+Raw traits: do **not** emit a `traits` array by default (most values duplicate `kind`).
+For debugging/forward-compat, gate a verbatim `"traits":[…]` field behind
+`PHONE_REMOTE_ELEMENTS_TRAITS=1`, mirroring the `snapshot_settings_from_env` opt-in
+pattern already in `wda.rs`.
+
+No-regression analysis against the snapshot-token model:
+
+- `element_snapshot_id` hashes the serialized rows (`http.rs:2906`), so new sparse
+  fields change tokens only across daemon versions, never within a session —
+  the token is already documented as ephemeral and cache capacity is 8.
+- `diff_element_rows` identity is `(kind, label, identifier, placeholder)`
+  (`http.rs:2976`) — untouched. New fields land on the *changed*-detection side,
+  which is desirable: a tab flipping to `selected:true` now correctly shows as
+  `changed` instead of `unchanged`.
+- Trait stability: traits and min/max are static per control in practice
+  (`UpdatesFrequently` etc. are bits, not live values), so tokens do not churn faster
+  than today. `value` already changes more often than any new field will.
+- All fields default to `None` → byte-identical JSON for every element that has no
+  affordance, matching the `enabled`/`visible` sparse precedent exactly.
+
+### 2.2 Generic invoke: `{"type":"perform", …}`
+
+Request (both `POST /agent/input` control messages and `/agent/actions` steps):
+
+```json
+{"type":"perform","element":12,"snapshot":"aX3…","action":"increment"}
+{"type":"perform","element":12,"snapshot":"aX3…","action":"menu","duration_ms":1200}
+{"type":"perform","element":12,"snapshot":"aX3…","action":"adjust","value":"0.7"}
+```
+
+Action vocabulary v1 (allowlist, fail-closed):
+
+| `action` | WDA dispatch (after the existing `fetch_snapshot_row` → `resolve_snapshot_row_element` pipeline) | extra params |
+|---|---|---|
+| `increment` / `decrement` | PickerWheel → `/wda/pickerwheel/:uuid/select` `{order:"next"/"previous",offset:0.2}`; Stepper → click the child Increment/Decrement `Button` (resolve via class-chain under the stepper); Slider → read `value,min,max`, step 10% of range, `POST element/:id/value` | — |
+| `adjust` | PickerWheel → `element/:id/value` (= `adjustToPickerWheelValue`, today's `picker` path); Slider → `element/:id/value` with normalized 0..1 | `value` (string, required) |
+| `menu` | `/wda/element/:uuid/touchAndHold` `{duration: duration_ms/1000, clamped 0.3–2.0s}` — the `perform_secondary_action` analogue: iOS's secondary-action surface *is* the long-press context menu | `duration_ms?` |
+| `double_tap` | `/wda/element/:uuid/doubleTap` | — |
+| `two_finger_tap` | `/wda/element/:uuid/twoFingerTap` | — |
+| `scroll_to_visible` | `/wda/element/:uuid/scrollTo` | — |
+| `toggle` | `element/:id/click` after asserting kind Switch / trait ToggleButton (semantic alias so agents need not special-case) | — |
+
+Held back from v1 (add when a real task needs them): `pinch`, `rotate`, `force_press`,
+`press_and_drag` (needs a second element target — new request shape), n-tap.
+
+Response grammar: unchanged from every other snapshot-bound action — `{"ok":true}` on
+success; failures reuse the existing fail-closed taxonomy verbatim
+(`invalid_element_snapshot`, `stale_element_snapshot`, `element_not_found`,
+`ambiguous_element_label`, `invalid_element_target`, `not_sent`/`outcome_unknown`
+with `retry_safe`). Two additions:
+
+- `unsupported_perform_action` — `action` not in the allowlist. `outcome:"not_sent"`,
+  `retry_safe:false` (mirrors `unsupported_control`: retrying identical input cannot
+  succeed).
+- Element cannot carry the action (e.g. `increment` on a plain Button, `adjust` on a
+  Cell): **reuse `invalid_element_target`** rather than minting a new code — its
+  meaning is already "the matched element cannot carry this action", and its hint
+  field can name the missing affordance. Keeps the taxonomy closed.
+
+`SnapshotElementTapError` needs no new variants; the WDA-404 → `NotFound` remap
+(`wda_error_is_missing_element`) applies to the new element routes identically.
+`/wda/pickerwheel/:uuid/select` failures where the wheel refuses to move surface as
+`AfterDispatch` (dispatched, outcome honest) — same contract as today's `picker`.
+
+Batch validation (`validate_agent_action_value`), matching house style:
+
+- `perform` requires `element` (u64) + `snapshot` (1–200 chars) + `action` (allowlist
+  string); `duration_ms` optional u64 ≤ 10 000; `value` required iff `action=="adjust"`,
+  ≤ 500 chars, forbidden otherwise; any unknown extra key for the given action →
+  `invalid_actions_request` with a `steps[i]` detail.
+- No `perform` action is uninstall-grade; no destructive-action carve-out needed
+  (`menu` can reach Delete items, but so can `tap` — no new trust boundary).
+
+### 2.3 Relationship to existing actions — alias or keep?
+
+**Keep everything; nothing breaks; `perform` owns only what has no home today.**
+
+| existing | verdict |
+|---|---|
+| `picker` (`adjustToPickerWheelValue` by column) | **Keep.** It is column-addressed (no snapshot needed) and hardware-validated (issue #23). `perform:"adjust"` on a PickerWheel row becomes the snapshot-bound sibling; document `picker` as the label-free/column form. Internally both bottom out in the same WDA call — share the client method, don't alias the wire format. |
+| `set_value` | **Keep, and tighten.** Formally scope it to text-bearing kinds (TextField/SecureTextField/SearchField/TextView) at validation time; route Slider/PickerWheel writes to `perform:"adjust"`. Today's accidental slider-adjust via `set_value` becomes explicit instead of surprising. (Compat: nobody documented the accident; tightening is safe.) |
+| `longpress` (coordinate) | **Keep.** It is the coordinate-mode primitive and the browser client sends it. `perform:"menu"` is the element-scoped semantic twin — same relationship `tap {x,y}` already has to `tap {element}`. Do not alias. |
+| element `scroll` (`{element,dx,dy}` via W3C actions inside the rect) | **Keep as-is** — it is delta-based and validated. WDA's `/wda/element/:uuid/scroll {toVisible/predicateString}` is a *different*, stronger affordance ("scroll container until child X is visible"); if adopted later it should be a new `scroll_until` step, not a change to `scroll`. `perform:"scroll_to_visible"` covers the self-scoped case cheaply now. |
+| `tap {element}` | Unchanged; `perform` deliberately has no `"tap"` so there is exactly one way to tap. |
+
+This keeps `perform` = "invoke a *named affordance* on a snapshot-bound element",
+while geometry stays with the existing gesture verbs. One new action type, zero
+re-shaped old ones.
+
+## 3. Honest limits (what LUMOS-grade affordance data WDA cannot give us)
+
+1. **Custom actions are unreachable.** `UIAccessibilityCustomAction` lists (the
+   rotor/"Actions available" items VoiceOver announces — e.g. Mail's per-row
+   Archive/Flag) cross neither XCUITest's public API nor WDA v9.15.3. They live as
+   name+target+selector objects inside the app process; the AX serialization that
+   testmanagerd hands XCUITest does not carry them.
+2. **Fork scope, if ever wanted:** the repo pins WDA by tag, so a small carried patch
+   is thinkable. WDA already injects custom snapshot request parameters
+   (`Categories/XCAXClient_iOS+FBSnapshotReqParams.m`) — the patch would add the AX
+   custom-actions attribute to the requested set and a
+   `POST /wda/element/:uuid/performAccessibilityAction` route calling private
+   `XCAXClient` machinery. Estimated 2–4 days of fork spike work with a **genuinely
+   uncertain outcome** (it is unknown whether testmanagerd serializes the attribute
+   across the process boundary at all; names might come through, invocation might
+   not). Recommendation: do not schedule until the trait-based tier proves
+   insufficient on a real task.
+3. **`Adjustable` without a typed control is advisory only.** For an `Other` row with
+   the `Adjustable` trait there is no WDA increment path (no pickerwheel route, no
+   min/max, no child buttons guaranteed). Emitting `["increment","decrement"]` for it
+   tells the agent the affordance *exists*; `perform` on it must return
+   `invalid_element_target` until a fork adds real AX increment. Option: mark these
+   `actions:["increment?","decrement?"]`… — rejected, sparse strings should stay
+   machine-exact; instead only emit derived actions for kinds we can actually drive
+   (PickerWheel/Stepper/Slider/Switch), and surface bare `Adjustable` via the
+   env-gated raw `traits` field until driveable.
+4. **`hittable` stays out of the tree** at this WDA version (attribute-only, N+1
+   round-trips); `ToggleButton`/`SupportsZoom` traits require the runner to be built
+   with a modern Xcode (true for this repo's setup scripts).
+5. Trait fidelity varies by framework: SwiftUI sometimes materializes different
+   trait/type combinations than UIKit for the "same" control; the derivation table
+   keys on both `kind` and traits for that reason.
+
+## 4. Feasibility verdict
+
+**Feasible, and cheaper than expected — the core requires no WDA change at all.**
+`traits`, `minValue`, and `maxValue` are already present in every `/source?format=json`
+response the daemon fetches; surfacing affordances is a parse-and-derive change in
+`flatten_tree` plus one new snapshot-bound action type that reuses the entire existing
+`fetch_snapshot_row`/`resolve_snapshot_row_element`/error-taxonomy pipeline and
+WDA's existing element-scoped routes. The only out-of-reach piece is
+`UIAccessibilityCustomAction` (WDA has zero support; a carried fork patch is a 2–4 day
+spike with uncertain yield) — everything else in the LUMOS pattern maps onto data WDA
+already emits.
+
+### Next-step spike (recommended)
+
+Behind `PHONE_REMOTE_ELEMENTS_AFFORDANCES=1` (default off ⇒ byte-identical JSON):
+
+1. Parse `traits` / `minValue` / `maxValue` in `flatten_tree`; emit sparse
+   `selected`, `min`, `max`, and derived `actions` per §2.1, with unit tests mirroring
+   `flatten_captures_value_for_switch_slider_picker`.
+2. Hardware-validate on Settings (Wi-Fi switch → `toggle`; Brightness slider →
+   `min/max/actions`), a date picker (`PickerWheel` → `increment`), and one tab bar
+   (`selected:true`), confirming token/delta behavior is unchanged with the flag off.
+
+Estimated effort: **0.5–1 day** including tests (no daemon-protocol change, no web
+client change). The `perform` action itself is the follow-up: ~1–2 days, starting with
+`increment`/`decrement`/`menu` only, since those three unlock pickers, steppers, and
+context menus — the concrete tasks (date pickers, quantity steppers, per-row menus)
+that today force coordinate guessing.

--- a/docs/research/2026-09-semantic-intents-channel.md
+++ b/docs/research/2026-09-semantic-intents-channel.md
@@ -1,0 +1,383 @@
+# Semantic intents channel — App Intents / Shortcuts as a first-class agent path
+
+*Research & design doc (no implementation). 2026-09. Target: iOS 27 / Xcode 26.6, daemon Direct/WDA backend.*
+
+## 中文摘要
+
+本文设计一条"语义通道"：当目标应用通过 App Intents / 快捷指令暴露了原生动作时，agent 可以直接调用它拿到结构化 JSON 结果，而不是靠视觉驱动 UI。核心发现：WDA 自带一个免会话的 `POST /url` 端点，守护进程可以用它在手机上直接打开 `shortcuts://run-shortcut?...` 深链，把现有实验桥的"剪贴板 + Spotlight 打字"触发方式替换成一次设备内调用，返回路径继续复用已有的 `/agent/inbox`。App Intents 本身无法从手机外部枚举或直接调用，所以语义通道必须以快捷指令为代理、以仓库内 `registry.json` 为唯一能力清单——这是诚实的边界，不是缺陷。该通道是纯增量的可选路径：注册了 verb 且桥健康时走语义调用，否则回落到现有 AX/快照令牌/受控批处理的 UI 通道，后者不做任何改动。结论：现在即可行（有限制条件），建议先做一次 `battery` verb 的 WDA-URL 触发端到端验证，约半天工作量。
+
+---
+
+## 1. The existing Shortcuts RPC bridge — how it actually works today
+
+The repo already contains a working (experimental, mirror-era) RPC bridge. Reconstructed
+from `shortcuts/README.md`, `shortcuts/registry.json`, and `crates/server/src/http.rs`:
+
+### 1.1 Trigger path (legacy, Mirroring-only)
+
+```
+daemon writes {"verb":"battery","id":"abc","args":{}} to the *Mac* clipboard
+  → (iPhone Mirroring shares the clipboard with the phone)
+  → open Spotlight on the mirrored phone, type "iU Bridge", press return
+  → the "iU Bridge" shortcut runs: reads the clipboard, dispatches on `verb`,
+    executes the native action (Get Battery Level, …)
+```
+
+The trigger is **not** a URL scheme, not devicectl — it is ordinary UI automation
+(Spotlight + typed text) plus the Mirroring shared clipboard as the parameter carrier.
+That is why README.md §"Shortcuts bridge (legacy mirror experiment)" pins it to
+`PHONE_REMOTE_BACKEND=mirror`: the Direct/WDA backend types text on-device, so the Mac
+clipboard never reaches the phone, and the whole carrier disappears.
+
+### 1.2 Return path (still shipped, backend-agnostic)
+
+The return half lives in `crates/server/src/http.rs` and works today under any backend:
+
+- `POST /agent/inbox` — the shortcut's *Get Contents of URL* action POSTs
+  `{"id":"abc","verb":"battery","ok":true,"data":{...}}` to the daemon with
+  `Authorization: Bearer <token>` + `X-Phone-Control: 1`. Non-JSON bodies are wrapped;
+  each item is stored with a `received_at` timestamp in a bounded queue
+  (`INBOX_CAP = 64`, oldest dropped).
+- `GET /agent/inbox` — non-destructive peek.
+- `POST /agent/inbox/drain` — atomic consume; the agent matches results on `id`.
+
+### 1.3 Governance model (worth keeping verbatim)
+
+`shortcuts/registry.json` is the deliberate answer to "how do we know what the phone can
+do": **one** bridge shortcut ("iU Bridge") with branches per `verb`; the registry file in
+the repo — not the phone — is the source of truth; agents never create shortcuts on the
+fly; adding a verb is a reviewed change. One verb (`battery`) validated the round trip;
+`health_*`, `location`, `send_message`, `create_reminder` are `planned`.
+
+### 1.4 Limitations of the current design
+
+1. **Dead under Direct.** The trigger needs Mirroring's shared clipboard and Mac-side
+   key events. Direct/WDA is now the product path, so the bridge is effectively offline.
+2. **Fragile trigger.** Spotlight typing is the least reliable primitive in the repo's
+   own hardware history (Search-pill tap flakiness, CN IME hijacking typed characters).
+3. **Clipboard as carrier** clobbers whatever the user had on the clipboard.
+4. **No request/response correlation enforcement** — correlation is by convention
+   (`id` matching after a drain); no timeout semantics, no outcome taxonomy
+   (`outcome`/`not_sent`/`retry_safe`), unlike every other mutation path in the daemon.
+5. **No liveness signal** — nothing tells an agent whether the bridge shortcut is
+   installed, what version it is, or which verbs the installed copy actually implements.
+
+---
+
+## 2. Phone-side trigger mechanisms — feasibility from a Mac daemon
+
+Evaluated against: unlocked requirement, confirmation prompts, parameter passing,
+return values, headless operation.
+
+### 2.1 `shortcuts://run-shortcut` deep link, opened on-device via WDA `POST /url` ★ recommended
+
+WebDriverAgent (the appium-webdriveragent the daemon already manages) exposes
+`POST /url` — verified against the current source (`FBSessionCommands.m`, appium-webdriveragent 9.x):
+
+- Route: `[[FBRoute POST:@"/url"] respondWithTarget:... action:@selector(handleOpenURL:)]`,
+  **sessionless** (also usable without an active WDA session).
+- Body: `{"url": "...", "bundleId": "<optional handler app>", "idleTimeoutMs": <optional>}`.
+- Implementation uses the modern `XCUIDevice`/system `open` path — no Safari detour.
+
+So the daemon can execute, entirely on-device, over the already-relayed `:8100`:
+
+```
+POST http://127.0.0.1:8100/url
+{"url":"shortcuts://run-shortcut?name=iU%20Bridge&input=text&text=%7B%22verb%22%3A%22battery%22%2C%22id%22%3A%22abc%22%7D"}
+```
+
+Apple documents `shortcuts://run-shortcut?name=[name]&input=[input]&text=[text]`:
+`input=text` passes the URL-encoded `text` parameter as the shortcut's input —
+**this replaces the clipboard carrier**; `input=clipboard` remains a documented
+fallback for oversized payloads (with the clobbering caveat).
+
+Properties:
+
+| Question | Answer |
+|---|---|
+| Phone unlocked? | Yes — same requirement as the whole Direct channel (`drivable:true`). No regression, no new locked-phone capability. |
+| Confirmation prompts? | No per-run confirmation for a manually-installed shortcut. One-time prompts: per-privacy-domain on first use of a sensitive action (Health, Location…), and once per destination host for *Get Contents of URL* ("Allow 'iU Bridge' to connect to `<mac>`?"). Same "expensive once, free after" model as the vision→script flow. |
+| Parameters? | Yes, URL-encoded JSON via `input=text&text=…`. Practical URL length is finite (keep request payloads ≤ ~2 KB; larger args should be fetched by the shortcut from a daemon endpoint by id). |
+| Return values? | Not via the URL itself. `x-callback-url` (`shortcuts://x-callback-url/run-shortcut?...&x-success=…`) only *opens another URL* on completion — it cannot carry structured results to a Mac. The existing `/agent/inbox` POST **is** the return path; keep it. |
+| Headless? | Partially. The run itself needs no human, but the Shortcuts app comes to the **foreground** for the duration of the run — it steals the screen from whatever UI flow was in progress. |
+
+### 2.2 `xcrun devicectl device process launch --payload-url` — fallback trigger
+
+`xcrun devicectl device process launch --device <udid> --payload-url "shortcuts://run-shortcut?..." com.apple.shortcuts`
+(iOS 17+, Xcode 15+) launches Shortcuts with the deep link from the Mac, over the same
+CoreDevice pairing the daemon already depends on for WDA builds.
+
+- Unlocked: required in practice for the app to come foreground and run.
+- Prompts / params / returns: identical to 2.1 (it is the same deep link).
+- Value: works when WDA is down (e.g. runner crash) but the CoreDevice tunnel is up.
+- Caveats: inherits the WARP/VPN CoreDevice-tunnel fragility documented in the skill;
+  spawning `xcrun` per call is slow (~seconds); `--payload-url` delivery has known
+  platform quirks (documented broken on tvOS; verify on iOS 27 during the spike).
+  Treat as a degraded fallback, not the primary path.
+
+### 2.3 Direct App Intents invocation from outside the phone — **not possible**
+
+There is no public mechanism for a Mac process to enumerate or invoke another app's
+App Intents on a phone. App Intents are reachable only through on-device brokers: Siri,
+Spotlight, widgets, the Action button, and the Shortcuts app. WWDC 2026 / iOS 27
+("App Intents 2.0": streaming responses, multi-turn follow-ups, on-screen awareness;
+SiriKit deprecated in favor of App Intents) changes none of this externally — if
+anything it confirms Shortcuts/Siri as the only broker. **Conclusion: the semantic
+channel must go through a Shortcut**, which can call any app's App Intent as an action
+step. This is a hard boundary, and the design below treats it honestly: discovery is a
+curated registry, not runtime enumeration.
+
+### 2.4 Custom URL schemes of target apps
+
+`POST /url` can equally open `things:///add?...`, `omnifocus://…`, etc. Fire-and-forget:
+no return value, no completion signal, schema undocumented per app, and success is only
+observable by reading the resulting UI (i.e. you are back to the AX channel for
+verification). Useful as an *optimization inside* a UI flow (deep-link to the right
+screen, then AX-verify), not as a semantic call. Out of scope for the RPC surface;
+worth a follow-up `{"type":"open_url"}` action proposal with its own allowlist.
+
+### 2.5 Push-based / automation triggers
+
+iOS 27 added notification, screenshot, and keyboard-connection automation triggers, and
+personal automations can run without per-run confirmation. In theory a
+notification-triggered automation could run a bridge verb without foregrounding
+Shortcuts, and some time-triggered automations run even locked. But the daemon has no
+APNs path to the phone, delivery would ride on a third-party messaging app, latency and
+reliability are uncharacterizable, and iCloud-synced automations are user-editable
+state. **Not a foundation** — file under future work if a locked-phone read-only verb
+ever becomes a requirement.
+
+### 2.6 Summary matrix
+
+| Mechanism | Unlocked needed | Prompts | Params in | Results out | Headless | Verdict |
+|---|---|---|---|---|---|---|
+| WDA `POST /url` → `shortcuts://run-shortcut` | yes (= `drivable`) | one-time grants only | URL-encoded JSON | via `/agent/inbox` | no human, but steals foreground | **primary** |
+| `devicectl … --payload-url` | yes | same | same | same | same | fallback when WDA down |
+| Direct App Intent invocation | — | — | — | — | — | impossible from outside; Shortcuts is the broker |
+| Custom URL schemes | yes | varies | in URL | none | fire-and-forget | optimization only, out of scope |
+| Automation/push triggers | sometimes not | none per-run | indirect | via inbox | yes | future work, not a foundation |
+
+---
+
+## 3. Proposed action surface (additive; no change to existing endpoints)
+
+Naming note: the action type `"shortcut"` is **taken** — in `/agent/input` grammar it
+means UI shortcuts (`home`/`spotlight`). The semantic channel uses `intent` everywhere
+to avoid the collision.
+
+### 3.1 `POST /agent/intent` — one semantic call, one bounded round trip
+
+Dedicated endpoint rather than a new `/agent/input` type: a semantic call is
+seconds-long (app launch + native action + phone POST), returns a payload rather than
+an acknowledgement, and must serialize against UI actions (it steals the foreground) —
+so it takes the same WDA control lock as `/agent/input` / `/agent/actions`.
+
+Request (bearer auth + `X-Phone-Control: 1`, like every mutation):
+
+```json
+{
+  "verb": "battery",
+  "args": {},
+  "timeout_ms": 15000
+}
+```
+
+Daemon behavior (fail-closed at every step):
+
+1. Validate `verb` against the shipped registry (unknown → reject, nothing sent).
+2. Check verb `side_effect` class; generate a correlation `id` (server-side, never client-supplied).
+3. Trigger: WDA `POST /url` with `shortcuts://run-shortcut?name=<bridge>&input=text&text=<urlencoded {"verb","id","args"}>`.
+   If WDA is unreachable and devicectl fallback is enabled, use 2.2; otherwise fail `not_sent`.
+4. Await a matching `id` on the inbox (internally — items consumed by the endpoint are
+   not left for manual drains) up to `timeout_ms` (capped, e.g. 30 s).
+5. Restore foreground: issue the existing on-device Home action, then report.
+
+Response, success:
+
+```json
+{"ok":true,"verb":"battery","outcome":"applied","data":{"level":0.83,"charging":false},"elapsed_ms":2400}
+```
+
+Errors — same taxonomy as the rest of the daemon (`outcome` ∈ `applied|not_sent|unknown`,
+`retry_safe` honest):
+
+| `error` | `outcome` | `retry_safe` | Meaning |
+|---|---|---|---|
+| `intent_unknown_verb` | `not_sent` | `true` | verb not in registry; nothing dispatched |
+| `intent_bridge_unavailable` | `not_sent` | `true` | WDA (and fallback) unreachable before dispatch |
+| `intent_invalid_args` | `not_sent` | `true` | args fail the verb's declared schema |
+| `intent_timeout` | `unknown` | `false` for `side_effect:"write"`, `true` for `"none"/"read"` | URL dispatched, no inbox reply in time — the native action may have run |
+| `intent_bridge_error` | `applied` (the bridge ran) | per verb | bridge replied `{"ok":false,...}` — native action failed; bridge error passed through in `data` |
+
+`intent_timeout` on a `write` verb is the semantic twin of `outcome_unknown` in the UI
+channel: the agent must observe state (or a read verb) before retrying — never blind-replay
+`send_message`-class verbs. This mirrors the at-most-once rules already in SKILL.md.
+
+### 3.2 `GET /agent/intents` — discovery, honestly scoped
+
+Returns the registry the daemon shipped with, plus liveness:
+
+```json
+{
+  "bridge": {"name":"iU Bridge","required_version":3,
+             "installed":"unknown|yes|no","installed_version":2,
+             "last_ok_at":"2026-09-01T09:12:00Z"},
+  "verbs": [
+    {"verb":"battery","summary":"…","args_schema":{},"returns_schema":{},
+     "side_effect":"none","permission":"none","status":"validated"},
+    {"verb":"send_message","side_effect":"write","permission":"Messages",
+     "status":"planned","confirm":"operator"}
+  ]
+}
+```
+
+How `installed` is known — three honest tiers, cheapest first:
+
+1. **Mac-side `shortcuts list --show-identifiers`**: the Shortcuts library is
+   iCloud-synced, so the Mac CLI can confirm a shortcut named "iU Bridge" exists in the
+   account library *without touching the phone*. Sync lag applies; presence in the
+   library ≠ present on this phone if sync is off. Report `"unknown"` when the CLI
+   is unavailable or sync can't be assumed.
+2. **`ping` verb round trip** (new registry verb, zero permissions): returns
+   `{bridge_version}`; the daemon caches `installed_version` + `last_ok_at`. This is
+   the only *proof*; run it lazily on first `/agent/intent` or on operator demand,
+   never on a poll loop.
+3. Per-verb `status` stays what the registry review process says (`experiment` /
+   `validated` / `planned`) — the daemon never upgrades it at runtime.
+
+**What is deliberately NOT promised:** enumeration of arbitrary third-party App
+Intents. It is not technically possible from outside the phone (§2.3), and the
+registry-as-reviewed-allowlist is also the security model: agents cannot invoke
+native actions that a human didn't curate into the bridge.
+
+### 3.3 Registry schema extension (`shortcuts/registry.json` v3)
+
+Additive fields per verb: `args_schema` / `returns_schema` (JSON Schema subset),
+`side_effect` (`none|read|write`), `min_bridge_version`, `confirm`
+(`none|operator` — `operator` verbs, e.g. `send_message`, are rejected by
+`/agent/intent` unless the request carries an explicit `"operator_confirmed":true`
+that MCP only sets after a human confirmation, mirroring the flow-runner's
+irreversible-action gate). Bridge gains a mandatory `ping` verb returning its version.
+
+### 3.4 What does not change
+
+`/agent/input`, `/agent/actions`, `/agent/elements`, snapshot tokens, the guarded batch
+validator, `/agent/inbox` (kept for manual/legacy use and as the transport for the new
+endpoint) — all untouched. The semantic channel is a new endpoint plus one small
+`wda.rs` method (`open_url`, wrapping WDA `POST /url`). If later wanted inside
+`/agent/actions` batches, an `intent` step kind can be added — but foreground-stealing
+inside a UI batch interacts badly with `wait_for`, so that is explicitly future work.
+
+---
+
+## 4. Decision logic — when should an agent take which channel
+
+Prefer the **semantic channel** when *all* hold:
+
+- The task maps to a registered verb (check `GET /agent/intents` once per session).
+- The desired output is data (battery, Health samples, location) or a well-defined
+  native state change — not "look at a screen and decide".
+- No UI flow is mid-progress that must keep the foreground (the intent call will steal
+  and then Home-reset it).
+
+Prefer the **UI channel** when any hold:
+
+- No registered verb (the common case — the registry is deliberately small).
+- The task is exploratory, interactive, or needs visual/AX verification of an
+  app-specific screen.
+- The verb is `write`-class and the operator confirmation for it is easier to review as
+  a visible UI flow.
+
+How a skill/MCP client learns availability: `GET /agent/intents` becomes part of the
+session preamble next to `/agent/status`; MCP grows `phone_intents` (read) and
+`phone_intent` (call) tools. The skill doc teaches the same waterfall it already
+teaches for elements-vs-screenshot: *registry verb → semantic call; otherwise
+see→act→verify.* A failed semantic call with `outcome:"not_sent"` may fall back to the
+UI path automatically; `outcome:"unknown"` must first observe state.
+
+---
+
+## 5. Risks and open questions
+
+1. **Foreground theft & mutual exclusion.** The run flashes the Shortcuts app on the
+   physical phone (a human co-user sees it) and interrupts any UI-driving mid-flow.
+   Mitigation: WDA control lock shared with `/agent/input`, Home-restore after, and
+   skill guidance not to interleave.
+2. **One-time permission dialogs.** First use of each privacy domain and the
+   per-host network grant happen on the phone screen; on a headless rack phone these
+   block until someone taps. Mitigation: an operator "bless the bridge" checklist in
+   install docs (run each verb once interactively).
+3. **User-mutable state.** The shortcut lives in the user's iCloud-synced library:
+   renameable, editable, deletable, and sync can lag or resurrect old versions on a
+   restore. Mitigation: `ping`/version handshake before trusting a verb;
+   `min_bridge_version` per verb; treat mismatch as `intent_bridge_unavailable`.
+4. **Secrets.** The request URL (`text=` payload) transits WDA logs and Shortcuts run
+   history — it must never contain the bearer token or private args. The token lives
+   only inside the shortcut's stored POST headers (as today); rotation requires
+   re-editing the shortcut on-device (document this in the rotation runbook).
+5. **No return values / unknown schemas for third-party intents.** A verb wrapping a
+   third-party App Intent is only as good as that intent's output; many return nothing
+   or an opaque entity. The registry review must record `returns_schema` honestly, and
+   `returns_schema: {}` (nothing) is a valid, allowed answer — the agent then verifies
+   via the UI channel.
+6. **iOS version drift.** iOS 27 rebuilt Shortcuts around Apple Intelligence; the
+   `run-shortcut` URL scheme is still documented, but foreground behavior, prompt
+   wording, and the new automation triggers need hardware re-verification per major iOS
+   (the spike below is that verification). App Intents 2.0's streaming responses do not
+   reach the URL-scheme path.
+7. **URL length limits** for `input=text` are undocumented; the spike should probe the
+   practical bound and the design keeps args small by contract (≤ 2 KB, larger blobs
+   fetched by the shortcut from the daemon by `id`).
+8. **Inbox contention.** `/agent/intent` consuming matched items must not eat unrelated
+   manual-bridge results; matching strictly on server-generated `id` prefix scoping
+   (e.g. `intent-<uuid>`) keeps the legacy drain flow intact.
+
+---
+
+## 6. Feasibility verdict
+
+**Feasible now, with caveats.** Every link in the chain is verified available: WDA's
+sessionless `POST /url` (in the appium-webdriveragent the daemon already manages) can
+open the documented `shortcuts://run-shortcut?name=…&input=text&text=…` deep link
+on-device, parameters ride in the URL instead of the clipboard, and the shipped
+`/agent/inbox` return path already works under Direct. The caveats are structural, not
+blockers: the phone must be unlocked (`drivable:true`, same as the UI channel), the
+Shortcuts app steals the foreground during a call, first-run permission grants need one
+interactive blessing session, and discovery is a curated registry because App Intents
+are not externally enumerable — Shortcuts is the only broker Apple provides.
+
+## 7. Next-step spike (smallest end-to-end proof)
+
+**Goal:** one `battery` round trip under the Direct backend, no Spotlight, no clipboard.
+
+1. Edit the existing "iU Bridge" shortcut: take input from *Shortcut Input*
+   (`input=text`) instead of the clipboard; keep the clipboard branch as fallback.
+2. Add a `ping` branch returning `{"id":…,"verb":"ping","ok":true,"data":{"bridge_version":3}}`.
+3. From the Mac (daemon host, WDA relay up), no daemon changes yet — drive it by hand:
+   `curl -X POST http://127.0.0.1:8100/url -d '{"url":"shortcuts://run-shortcut?name=iU%20Bridge&input=text&text=%7B%22verb%22%3A%22battery%22%2C%22id%22%3A%22spike-1%22%7D"}'`,
+   then `POST /agent/inbox/drain` and match `spike-1`.
+4. Measure: trigger→inbox latency, foreground-steal duration, whether Home-restore is
+   needed, prompt inventory on a fresh install, practical `text=` size limit
+   (binary-search 1/2/4/8 KB), and the same trigger via
+   `xcrun devicectl device process launch --payload-url … com.apple.shortcuts` with WDA stopped.
+5. Record results in `SPIKE-RESULTS.md` style; only then implement `wda.rs::open_url`,
+   `POST /agent/intent`, `GET /agent/intents`, registry v3.
+
+**Effort:** spike ≈ half a day with phone in hand (coordinate with the hardware-test
+session; steps 3–4 touch `:8100` and the daemon). Follow-up implementation of the two
+endpoints + registry v3 + MCP tools + skill/README docs ≈ 2–3 days including hardware
+acceptance.
+
+---
+
+### Sources
+
+- Repo: `shortcuts/README.md`, `shortcuts/registry.json`, `crates/server/src/http.rs`
+  (inbox routes ~L588–592, dispatch ~L3544, `/agent/actions` validator ~L4362),
+  `crates/server/src/wda.rs` (`launch_app` L663), `README.md` §Shortcuts bridge, `skills/iphone-use/SKILL.md`.
+- [Apple: Run a shortcut using a URL scheme](https://support.apple.com/guide/shortcuts/run-a-shortcut-from-a-url-apd624386f42/ios)
+- [Apple: Use x-callback-url with Shortcuts](https://support.apple.com/guide/shortcuts/use-x-callback-url-apdcd7f20a6f/ios)
+- [Apple: Run shortcuts from the command line (macOS)](https://support.apple.com/guide/shortcuts-mac/run-shortcuts-from-the-command-line-apd455c82f02/mac) · [Sync shortcuts on Mac](https://support.apple.com/guide/shortcuts-mac/sync-shortcuts-apdb3a4240b0/mac)
+- [appium-webdriveragent `FBSessionCommands.m` (POST /url, sessionless)](https://cdn.jsdelivr.net/npm/appium-webdriveragent@9.0.6/WebDriverAgentLib/Commands/FBSessionCommands.m)
+- [Apple Developer Forums: devicectl `--payload-url`](https://developer.apple.com/forums/thread/744765) · [tvOS payload-url quirk](https://developer.apple.com/forums/thread/775693)
+- [WWDC26: What's new in Shortcuts](https://developer.apple.com/videos/play/wwdc2026/310/) · [TechCrunch: AI-built Shortcuts workflows](https://techcrunch.com/2026/06/08/apple-will-let-you-build-workflows-using-ai-in-its-new-shortcuts-app/) · [App Intents vs Shortcuts on macOS 27](https://elephas.app/resources/app-intents-vs-shortcuts) · [iOS 27 App Intents / agents strategy](https://ecorpit.com/ios-27-app-store-ai-agents-app-intents-developer-strategy-2026/)

--- a/docs/research/2026-09-visual-fallback-driver.md
+++ b/docs/research/2026-09-visual-fallback-driver.md
@@ -1,0 +1,458 @@
+# Visual fallback driver — AX-first, vision-fallback design
+
+**Status**: research / design (no code). 2026-09.
+**Scope**: what to build when the accessibility tree is unusable; nothing here
+changes the existing AX / snapshot-token / guarded-batch contract, which stays
+the primary and preferred channel.
+
+## 中文摘要
+
+iPhone 自动化目前完全依赖 WDA 的可访问性树（`/agent/elements`），但游戏、canvas
+应用、自绘 UI 会返回近乎空的树，而 KakaoTalk 这类超大树甚至会直接杀死手机上的
+WDA runner（issue #44）。本文设计一条可选的视觉降级通道：检测到 AX 树不可用时，
+改用「截图 → 视觉模型 → 归一化坐标动作」的循环，复用现有的 `tap/longpress/swipe`
+坐标动作。关键发现是：坐标动作走 W3C `/actions`、健康探测走 `/wda/apps/list`，
+两者都不解析 AX 层级，所以纯视觉循环天然绕开了 KakaoTalk 崩溃。推荐由 MCP/skill
+层编排（调用方自己就是视觉模型），daemon 只需增加只读的 `ax_stats` 统计字段，
+保持「薄而可靠」的哲学。结论：可行，且第一版几乎不需要 daemon 改动。
+
+---
+
+## 0. The two failure modes (and why one design covers both)
+
+Everything below is grounded in two documented, opposite failure modes:
+
+**Mode A — the tree is too sparse.** Games (Unity/Unreal), canvas/WebGL apps,
+and custom-drawn UI expose almost nothing to XCUITest. The repo has seen
+1-element trees where the only row is the `Application` node. The
+`/agent/elements` call *succeeds*, but the rows carry no actionable targets:
+no labels, no interactive kinds, rects covering a sliver of the screen.
+
+**Mode B — the tree is too large to read at all.**
+[Issue #44](https://github.com/leeguooooo/iphone-use/issues/44) (KakaoTalk,
+reproduced 3/3 on daemon 0.5.3): the moment KakaoTalk is foreground, *any*
+request that resolves the accessibility hierarchy kills the on-phone runner —
+`wda-runner.log` shows `Requesting snapshot of accessibility hierarchy for app
+with pid …` followed by `** BUILD INTERRUPTED **`. `/agent/elements` hangs
+past 25–40 s, the next action returns `outcome_unknown`, and status flips to
+`device_state:"blocked"`. Recovery costs a 1–3 min WDA rebuild, then it dies
+again on the next AX read. The same session drove Safari (91 elements) fine.
+
+Mode A means "AX gave you nothing to act on"; Mode B means "asking AX at all
+takes the device down". A vision channel that acts on **coordinates only** and
+**never resolves the hierarchy** handles both.
+
+### The load-bearing code fact
+
+Verified in the current source (`crates/server/src/wda.rs`):
+
+- Coordinate taps, long-presses, drags and swipes are dispatched through the
+  W3C Actions API — `POST /session/<sid>/actions` (`tap_point` at
+  `wda.rs:366`, with the same pattern for longpress/drag/swipe). **No AX
+  hierarchy snapshot is taken.**
+- The action-level health probe (`probe_health`, `wda.rs:91`) uses
+  `GET /wda/apps/list` + lock state — also snapshot-free (the comment at
+  `wda.rs:84` explicitly avoids `wda/activeAppInfo` for a related reason).
+- `GET /agent/screenshot` is a pixel capture; no hierarchy resolution.
+- `POST /agent/input` with `{"type":"tap","x":…,"y":…}` reads the element tree
+  **only** when `?return=delta` is requested (`http.rs:5411` — delta is read
+  only after `want_delta && outcome == Applied`).
+
+So the snapshot-free action channel the vision driver needs **already exists
+end to end**: screenshot → normalized-coordinate action → screenshot. The
+missing pieces are (1) deciding *when* to switch, (2) the model contract, and
+(3) a discipline that keeps implicit AX reads (`?return=delta`, element
+verification) out of the loop while a Mode-B app is foreground.
+
+---
+
+## 1. "Is the AX tree usable?" — detection signals
+
+### 1.1 Signals computable from the existing `/agent/elements` response
+
+The response is `{screen:{width,height}, snapshot, elements:[{kind, label,
+identifier?, rect:[x,y,w,h], depth, value?, enabled?, visible?, …}]}`. The
+daemon already filters rows to "non-empty label OR interactive kind"
+(`flatten_tree`, `wda.rs:974`, with the 11-kind `INTERACTIVE` list: Button,
+Cell, TextField, SecureTextField, SearchField, Switch, Slider, TextView,
+PickerWheel, Picker, Stepper). All of the following are pure functions of data
+already serialized:
+
+| Signal | Definition | Healthy screen (Safari, Home) | Mode-A screen (game/canvas) |
+|---|---|---|---|
+| `n` — element count | `elements.len()` | tens to ~200 | 0–3 |
+| `n_interactive` | rows whose `kind` ∈ INTERACTIVE | > 5 typical | 0 |
+| `labeled_frac` | interactive rows with non-empty `label` ÷ `n_interactive` (1.0 if none) | ≥ 0.6 | n/a (no interactive rows) |
+| `coverage` | area of the union of rects (clipped to `screen`) ÷ screen area | ≥ 0.5 | ≈ 0 or a full-screen single `Other`/`Application` rect |
+| `container_only` | every row's `kind` ∈ {Application, Window, Other, Image} | false | true |
+| `max_depth` | max of `depth` | ≥ 4 | ≤ 2 |
+
+Caveats worth encoding:
+
+- A **single full-screen rect** (the app's root `Other` at depth 1) makes
+  `coverage` ≈ 1.0 while being useless — that's why `container_only` and
+  `n_interactive` must gate coverage, not the other way round.
+- **Legitimately sparse screens exist**: a full-screen video player or photo
+  viewer has few elements but the few it has (a Button labeled "Done") are
+  correct. Low `n` alone must not trigger fallback; *zero usable targets for
+  the current intent* should.
+- **Mode B produces no response to score.** The signal is the read outcome
+  itself: `/agent/elements` returning 504 `wda_source_timeout` / 502
+  `wda_source_failed` (with `transitioning:true`) while `GET /agent/screenshot`
+  still succeeds, twice in a row on the same foreground app. After issue #44's
+  requested fix (bounded snapshot timeout that fails the request instead of
+  the runner), this becomes a clean, cheap signal; today it is expensive
+  (runner rebuild), which argues for **remembering the verdict per app** so
+  the probe is paid at most once per app per session.
+
+### 1.2 Proposed scoring heuristic
+
+Score in three tiers rather than a single scalar — the actions differ:
+
+```
+ax_verdict(elements_response | read_failure) -> usable | degraded | unusable
+
+unusable  (go vision):
+    read failed twice (Mode B: elements 502/504 while screenshot 200), OR
+    n_interactive == 0 AND container_only                        (Mode A)
+
+degraded  (hybrid: AX for what it has, vision for the rest):
+    n_interactive < 3, OR labeled_frac < 0.3, OR
+    (coverage < 0.3 AND NOT container_only)
+
+usable    (stay AX-only; today's behavior):
+    everything else
+```
+
+Thresholds are starting points to calibrate against stored trees (a Safari
+tree, a Home-screen tree, a known game tree); the shape — a
+zero-interactive-targets test plus a read-failure test, with a hybrid middle
+band — matters more than the exact constants.
+
+### 1.3 Where it lives: stats in the daemon, policy in the skill/client
+
+Split it:
+
+- **Daemon: computes and reports, never decides.** Add an additive, optional
+  `ax_stats` object to the `/agent/elements` response:
+  `{"n":…, "n_interactive":…, "labeled_frac":…, "coverage":…,
+  "container_only":…, "max_depth":…}`. This is a pure function of rows it
+  already serializes (a sibling of `elements_delta_json`), costs microseconds,
+  cannot regress any existing client (new key, same response otherwise), and
+  gives every client — skill, MCP, browser drawer, future flows — one shared,
+  unit-tested implementation instead of N divergent ones.
+- **Skill/MCP layer: applies thresholds and owns the switch.** Whether to go
+  vision is *policy* — it depends on task intent ("read the score" vs "tap the
+  button"), cost tolerance, and model availability, none of which the daemon
+  knows. The skill doc gets a short "when the tree is unusable" section citing
+  `ax_stats`; the MCP server can surface a convenience verdict.
+- The Mode-B signal (read failed, screenshot works) needs no new code at all —
+  both statuses are already distinguishable by the client today.
+
+This respects the repo's thin-daemon philosophy: the daemon stays a
+deterministic device driver; judgment stays with the model that has the task
+context.
+
+---
+
+## 2. Visual driver interface
+
+### 2.1 The contract
+
+Provider-agnostic, defined so the model behind it is swappable. Input is what
+the daemon already produces; output is one of the **existing** action JSONs —
+no new action types, so the daemon needs zero changes to execute a
+vision-driven step.
+
+```jsonc
+// VisualGroundingRequest
+{
+  "screenshot_png_b64": "…",           // from GET /agent/screenshot, verbatim
+  "screen": {"width": 393, "height": 852},  // points, from /agent/elements
+                                            // or screenshot metadata
+  "instruction": "tap the paperclip / attach button in the message bar",
+  "history": [                          // optional, last k steps for loops
+    {"action": {…}, "observed": "keyboard appeared"}
+  ],
+  "hints": {                            // optional, hybrid mode (§1.2 degraded)
+    "known_elements": [ /* the few usable ElementRows, as-is */ ]
+  }
+}
+
+// VisualGroundingResponse
+{
+  "action": {"type": "tap", "x": 0.708, "y": 0.089},  // EXISTING schema:
+      // tap | longpress (+duration_ms) | swipe/scroll (x,y,dx,dy) — normalized [0,1]
+  "confidence": 0.86,                  // 0..1, calibration per provider
+  "reasoning": "attach icon is the leftmost glyph in the input bar",
+  "target_description": "paperclip icon, bottom-left of message field",
+  "abstain": false                     // true => no action field; see §4
+}
+```
+
+As Rust, for whenever a native integration is wanted (not v1):
+
+```rust
+#[async_trait]
+trait VisualGrounder {
+    async fn ground(&self, req: GroundingRequest) -> Result<GroundingResponse>;
+}
+// impls: CallingAgent (implicit, see below), OpenAiCompatible { base_url, model },
+// future: local vLLM / CoreML.
+```
+
+An OpenAI-compatible chat-completions endpoint is the pragmatic wire format —
+UI-TARS ships served by vLLM/SGLang exactly that way, and every hosted VLM
+speaks it; the trait keeps the daemon-side door open without committing to it.
+
+### 2.2 Who calls the model: skill/MCP orchestration, not the daemon
+
+**Recommendation: the MCP/skill layer orchestrates** (screenshot → model →
+coordinate action). The daemon does not gain a model client, API keys, or new
+config in v1. Reasons, in order of weight:
+
+1. **The thin-daemon philosophy is load-bearing here.** The daemon's value is
+   deterministic device control with a strict outcome grammar
+   (`outcome`/`retry_safe`, at-most-once mutation, guarded batches). A model
+   call is the opposite kind of dependency: slow (seconds), nondeterministic,
+   networked, key-managed, and versioned. Putting it inside `agent_input`
+   would couple WDA-lock hold times to model latency and turn model outages
+   into device-state errors.
+2. **The calling agent already has everything.** It receives screenshots, has
+   the task context (which the daemon never has — "tap the attach button" is
+   not expressible in the daemon's vocabulary), and can already emit
+   `{"type":"tap","x":…,"y":…}`. For the default provider (§3.4) the "call"
+   is not even an HTTP request — it's the agent reasoning over the screenshot
+   it just fetched.
+3. **Privacy stays a user choice.** Screenshots of banking/IM apps leaving the
+   Mac should be decided by whoever configures the orchestrator, not baked
+   into the device daemon. A daemon that phones a vision API is a much bigger
+   trust surface than one that serves pixels to an authenticated local client.
+4. **Swappability is free at the skill layer.** Pointing the skill/MCP at a
+   local UI-TARS vLLM endpoint vs. using the agent's own eyes is a
+   configuration of the orchestrator; redeploying the daemon for a model swap
+   would be backwards.
+
+What the daemon *should* add (all additive, all optional):
+
+- `ax_stats` on `/agent/elements` (§1.3).
+- A documented **"vision-safe" discipline**: while driving a Mode-B app, the
+  client must not send `?return=delta`, element/label taps, or `wait_for`
+  element gates — anything that resolves the hierarchy. This is documentation
+  plus perhaps a skill-level lint, not daemon enforcement, in v1. (A future
+  `?no_ax=1` hint that makes the daemon refuse accidental AX reads for the
+  request would be a small, honest guard.)
+- Optionally, cheap screenshot metadata to help verification (§4): e.g.
+  `X-Screenshot-Hash` header (perceptual hash) so a client can detect "screen
+  changed" without re-downloading identical PNGs. Nice-to-have, not required.
+
+Env-style config, if/when a daemon-side provider is ever wanted, follows the
+existing convention: `PHONE_REMOTE_VISION_URL`, `PHONE_REMOTE_VISION_TOKEN`,
+`PHONE_REMOTE_VISION_MODEL`. Explicitly **out of scope for v1**.
+
+---
+
+## 3. Model options (researched 2026-09; verify before building)
+
+### 3.1 Apple Ferret-UI Lite
+
+- 3B end-to-end GUI agent for mobile/web/desktop; paper Sep 2025
+  ([arXiv 2509.26539](https://arxiv.org/abs/2509.26539)), publicized wider
+  Feb 2026 ([Apple ML Research](https://machinelearning.apple.com/research/ferret-ui),
+  [InfoQ](https://www.infoq.com/news/2026/02/apple-ferret-ui-lite-on-device/)).
+- Grounding: **91.6% ScreenSpot-V2, 53.3% ScreenSpot-Pro, 61.2% OSWorld-G** —
+  competitive with far larger models at 3B, sized for on-device.
+- **Blocker: licensing.** The lineage ships under research-only terms — the
+  Ferret family repo ([apple/ml-ferret](https://github.com/apple/ml-ferret))
+  and the Ferret-UI data are CC BY-NC / research-use; nothing indicates a
+  commercially usable checkpoint, and no OS-integrated API exists yet. For a
+  shipping tool, **not usable today**; watch for it surfacing as an Apple
+  Intelligence system capability instead.
+
+### 3.2 ByteDance UI-TARS
+
+- The one **actually deployable open** option:
+  [UI-TARS-1.5-7B](https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B),
+  **Apache-2.0**, weights on Hugging Face, served via vLLM or SGLang
+  (`vllm serve ByteDance-Seed/UI-TARS-1.5-7B`). Model card:
+  **94.2% ScreenSpot-V2, 61.6% ScreenSpot-Pro, 64.2 AndroidWorld** — the
+  strongest published mobile grounding among open checkpoints.
+- [UI-TARS-2](https://arxiv.org/abs/2509.02544) (Sep 2025) improves further,
+  but as of this research **UI-TARS-2 weights are not on Hugging Face**
+  (open [request issue #213](https://github.com/bytedance/UI-TARS/issues/213));
+  it's paper + hosted demo. Plan around 1.5-7B.
+- Serving cost: a 7B VLM wants a real GPU (≥ ~24 GB VRAM comfortable for
+  bf16; quantized GGUF variants exist for less). On the user's Apple-Silicon
+  Macs this means either a quantized local run (slower, seconds/step) or a
+  small GPU box/cloud endpoint. Latency per grounding call on a served GPU:
+  roughly sub-second to ~2 s; local quantized: several seconds.
+- Privacy: self-hostable — screenshots never leave the LAN. This is its main
+  argument beside cost-per-step.
+
+### 3.3 Generic multimodal LLMs (Claude / GPT / Gemini via API)
+
+- Grounding on **dense desktop** UIs is historically the weak spot —
+  [ScreenSpot-Pro](https://huggingface.co/blog/Ziyang/screenspot-pro) measured
+  GPT-4o at **0.8%** vs. specialist models' 40–60%. But ScreenSpot-Pro is 4K+
+  professional desktop screens with tiny targets; it is the *wrong* benchmark
+  for this project.
+- The relevant regime is a **phone screen**: ~393×852 points, Apple-HIG
+  ≥ 44 pt touch targets, one column of content. That's ScreenSpot-V2-mobile
+  territory, where even mid-tier models score high and a normalized-coordinate
+  error of ±0.03 still lands inside the target. Frontier models with native
+  computer-use/pointing training (Claude's computer-use models, Gemini 2.5+)
+  are markedly better than the GPT-4o datapoint above, and — decisively —
+  the **calling agent already has the screenshot in context**, so the marginal
+  grounding call costs zero extra infrastructure, zero extra latency beyond
+  the reasoning it was doing anyway, and inherits the task context.
+- Cost: a screenshot + short prompt per step against a frontier API is the
+  most expensive per-step option in tokens, but it's only paid on fallback
+  screens, and the skill's existing "vision once → script forever" doctrine
+  (compile successful traces into flows) bounds the recurring cost.
+
+### 3.4 The honest comparison, including "do nothing in the daemon"
+
+| Option | Mobile grounding | Latency/step | Cost/step | Privacy | Deployable today |
+|---|---|---|---|---|---|
+| Calling agent (Claude/GPT) as grounder | good on phone-sized UI; weakest on dense/tiny targets | already in the loop | frontier tokens (fallback screens only) | screenshots already go to the agent's API today | **yes — zero new infra** |
+| UI-TARS-1.5-7B, self-hosted | best-in-class open (94.2 SS-V2) | ~1–2 s served; more if local-quantized | ~zero marginal after GPU | LAN-only possible | yes, needs a GPU endpoint |
+| Ferret-UI Lite | strong at 3B, designed on-device | would be great | — | best (on-device) | **no — research license** |
+| UI-TARS-2 | best published | — | — | — | no open weights yet |
+
+**Does a dedicated grounding model beat the calling agent today?** On
+benchmarks, yes — UI-TARS-1.5-7B out-grounds generic frontier models,
+decisively so on dense screens. **For this project, mostly no, not yet**: the
+fallback triggers on games/canvas/AX-broken apps shown on a *phone-sized*
+screen, where frontier-model grounding plus large touch targets is usually
+sufficient; the calling agent needs no GPU, no serving, no new privacy
+surface, and it already holds the task intent. The dedicated model becomes
+worth its GPU when (a) vision steps become frequent enough that token cost
+dominates, (b) targets get small (dense game HUDs, drawing apps), or (c) the
+user wants screenshots to stay on the LAN. The provider-agnostic contract in
+§2.1 is exactly what makes that a later config change instead of a redesign.
+
+**Recommendation: v1 = "do nothing in the daemon."** The skill/MCP layer
+implements the loop with the calling agent as the grounder; the §2.1 JSON is
+the *format the skill instructs the agent to emit*, so swapping in UI-TARS
+later is transparent.
+
+---
+
+## 4. Degradation strategy
+
+### 4.1 Low confidence / abstention
+
+- `confidence < 0.5` or `abstain:true` → **no dispatch**. Nothing was sent, so
+  this is by definition `outcome:"not_sent"`-equivalent, `retry_safe:true` at
+  the orchestrator level. Recovery ladder, in order: re-screenshot (the screen
+  may have settled/animated); ask the model again with a **cropped region**
+  around its best guess (cheap resolution boost — crop client-side, no daemon
+  change); switch strategy (scroll to bring the target into view); finally
+  report to the user with the screenshot and the model's
+  `target_description`.
+- Confidence never overrides the existing safety rules: destructive targets
+  (send / pay / delete / 2FA) keep requiring explicit verification regardless
+  of channel; a vision guess is *weaker* evidence than an AX label, never
+  stronger.
+
+### 4.2 Verifying a vision-driven tap landed
+
+- **Post-action screenshot diff is the primary verifier** in vision mode:
+  screenshot before, act, settle ~300–800 ms, screenshot after, compare
+  (pixel-diff fraction or perceptual hash + the model judging "did the
+  expected change happen?" on the after-image). The model-judged variant
+  doubles as re-orientation for the next step, so it costs one call, not two.
+- **`?return=delta` is explicitly forbidden in Mode B** — it resolves the
+  element tree after the action (`http.rs:5411`), which is precisely the
+  operation that kills the KakaoTalk runner. This is the sharpest correctness
+  edge in the whole design: the vision loop must be *hermetically* AX-free
+  for Mode-B apps. In Mode A (sparse but harmless tree), `return=delta` is
+  safe but usually uninformative — a game's tree doesn't change when you tap;
+  screenshot diff is the verifier there too. `return=delta` stays exactly
+  what it is today for the AX channel; no regression.
+- An unchanged screen after an applied tap is a *soft* failure: the tap may
+  have landed on dead space, or the UI may respond invisibly. One retry with
+  an adjusted target (model sees before+after and its own previous guess) is
+  reasonable; more than one is guessing — stop and report.
+
+### 4.3 Mapping onto the existing outcome / retry_safe taxonomy
+
+The daemon's grammar is untouched; the orchestrator layers vision semantics
+on top of it:
+
+| Situation | Daemon says | Orchestrator treats as |
+|---|---|---|
+| Model abstained / low confidence | (nothing sent) | `not_sent`, retry-safe, try recovery ladder |
+| Tap dispatched, applied | `ok:true` / `outcome:applied` | *dispatched*, not *achieved* — screenshot diff decides success |
+| Tap dispatched, `outcome_unknown` (502/504) | `retry_safe:false` | same rule as today: **read state (screenshot) before any replay**; vision mode already re-screenshots every step, so this integrates naturally |
+| `wda_pre_dispatch_failed` / transition | `not_sent`, `retry_safe:true` | safe to retry after status settles |
+| Applied but screen unchanged | `applied` | vision-level soft failure: one adjusted retry, then stop |
+
+Note the pleasant alignment: the skill already mandates "treat
+`outcome_unknown` as possibly executed; read a screenshot before resending."
+The vision loop makes that mandatory read structural rather than
+disciplinary.
+
+### 4.4 Session-level degradation
+
+- Cache the per-app verdict (`usable | degraded | unusable`, keyed by the
+  foreground app when known, else by screen signature) for the session, so
+  Mode-B apps pay the probing cost at most once.
+- Any successful AX read on a new screen flips the channel back — AX-first is
+  the invariant; vision is a screen-scoped fallback, not a session mode.
+- Every successful vision-driven sequence should feed the existing
+  "vision once → script forever" pipeline: coordinates get compiled into a
+  flow bound to a screen signature + postcondition, per the skill's existing
+  coordinate-fallback rules (SKILL.md §Self-improvement). Vision is how you
+  *discover* the flow, not how you run it the tenth time.
+
+---
+
+## Feasibility verdict
+
+**Feasible, and cheaper than expected.** The critical enabler is already
+shipped: coordinate actions go through W3C `/actions` and the health probe
+through `/wda/apps/list`, neither of which resolves the accessibility
+hierarchy — so a screenshot → VLM → normalized-coordinate loop works against
+today's daemon with **zero daemon changes**, and it is simultaneously the
+workaround for issue #44's runner-killing apps (provided the loop is kept
+strictly AX-free: no `/agent/elements`, no `?return=delta`, no element
+locators while such an app is foreground). The recommended v1 is skill/MCP
+orchestration with the calling agent as the grounder; the only daemon work
+worth doing is additive (`ax_stats` on `/agent/elements`, and the issue-#44
+bounded-snapshot fix, which is independently owed). A dedicated grounding
+model (UI-TARS-1.5-7B, Apache-2.0, vLLM-servable) is the clear upgrade path
+when cost, density, or privacy demand it; Ferret-UI Lite is license-blocked;
+UI-TARS-2 has no open weights yet.
+
+## Next-step spike (offline, no phone, no daemon changes)
+
+**Goal**: prove the contract end to end on stored pixels.
+
+1. Take 3 stored screenshots: one AX-empty app (a game or canvas app; if none
+   stored, any full-screen Unity game screenshot at iPhone resolution), one
+   KakaoTalk-like chat screen, one healthy control (Safari).
+2. For each, run one generic VLM (the calling agent itself — no new infra)
+   with the §2.1 prompt contract and a concrete instruction ("tap the
+   settings gear", "tap the attach button"), requiring the
+   `{action, confidence, reasoning, target_description}` JSON.
+3. Validate: (a) output parses as an existing `/agent/input` action schema
+   with in-range normalized coordinates; (b) overlay the predicted point on
+   the screenshot and eyeball whether it lands inside the true target;
+   (c) record per-screen hit/miss and confidence calibration.
+4. Deliverable: a scratch script + a table of hits/misses appended to this
+   doc.
+
+**Effort**: ~half a day. **Hardware follow-up** (needs the phone, separate
+session): verify on-device that a strictly AX-free loop (status → screenshot →
+coordinate tap → screenshot) survives inside KakaoTalk without killing the
+runner — that single experiment confirms both the issue-#44 workaround and
+the vision channel's viability, ~1–2 hours.
+
+## Sources
+
+- [Issue #44 — KakaoTalk a11y snapshot kills the WDA runner](https://github.com/leeguooooo/iphone-use/issues/44)
+- [UI-TARS-1.5-7B model card (benchmarks, Apache-2.0, vLLM serving)](https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B)
+- [UI-TARS GitHub](https://github.com/bytedance/ui-tars) · [UI-TARS-2 technical report](https://arxiv.org/abs/2509.02544) · [UI-TARS-2 weights request #213](https://github.com/bytedance/UI-TARS/issues/213)
+- [Ferret-UI Lite paper](https://arxiv.org/abs/2509.26539) · [Apple ML Research page](https://machinelearning.apple.com/research/ferret-ui) · [apple/ml-ferret (research license)](https://github.com/apple/ml-ferret) · [InfoQ coverage](https://www.infoq.com/news/2026/02/apple-ferret-ui-lite-on-device/)
+- [ScreenSpot-Pro benchmark](https://github.com/likaixin2000/ScreenSpot-Pro-GUI-Grounding) · [ScreenSpot-Pro results blog (GPT-4o 0.8%)](https://huggingface.co/blog/Ziyang/screenspot-pro)


### PR DESCRIPTION
Three parallel research design docs (leo-approved exploration pass; **draft — for prioritization, not merging as-is**). Each ends with a feasibility verdict + a concrete spike proposal. Common constraint honored throughout: no regression of the AX/snapshot-token/guarded model — everything additive.

| Track | Doc | Verdict | Proposed spike |
|---|---|---|---|
| A · Semantic channel (App Intents/Shortcuts) | `docs/research/2026-09-semantic-intents-channel.md` | **Feasible now, structural caveats** | ~0.5d hardware: `battery`+`ping` round trip via WDA sessionless `POST /url` → `shortcuts://run-shortcut` → `/agent/inbox` |
| B · Visual fallback driver | `docs/research/2026-09-visual-fallback-driver.md` | **Feasible, zero daemon changes for v1** | 0.5d offline VLM grounding + 1-2h hardware (AX-free loop inside KakaoTalk = #44 workaround) |
| C · Action affordances | `docs/research/2026-09-action-affordances.md` | **Highly feasible, no WDA fork for core** | 0.5–1d: parse already-on-the-wire `traits`/`minValue`/`maxValue` behind `PHONE_REMOTE_ELEMENTS_AFFORDANCES=1` + `{"type":"perform"}` |

Highlights:
- **A**: legacy Shortcuts bridge trigger (clipboard+Spotlight, mirror-only) replaceable by WDA sessionless `POST /url` (verified in FBSessionCommands.m) — the whole semantic channel fits inside Direct/WDA with one new `open_url` method; `devicectl --payload-url` as fallback. App Intents are NOT externally enumerable — curated registry is the only discovery model.
- **B**: coordinate taps and the health probe never resolve the AX hierarchy, so a strictly AX-free vision loop doubles as the #44 (KakaoTalk runner-death) workaround; `?return=delta` must be off in vision mode. Calling agent's own vision suffices to start; UI-TARS-1.5-7B (Apache-2.0) is the later dedicated-grounder upgrade; Ferret-UI Lite license-blocked.
- **C**: WDA v9.15.3 already emits `traits` + `minValue`/`maxValue` in every `/source` response — flatten_tree discards them today; element-scoped gesture routes (touchAndHold/doubleTap/pinch/rotate/…) support a generic snapshot-bound `perform` action reusing the existing resolve pipeline. Only unreachable piece: UIAccessibilityCustomAction (would need a carried WDA patch, 2–4d, uncertain yield — defer).

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU