### PR TITLE
feat(agent): element action affordances + snapshot-bound perform action

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ the heaviest users make the product better.
 | `PHONE_REMOTE_WDA_MANAGED` | on for Direct loopback endpoints | Whether this daemon owns the local WDA supervisor/relay lifecycle. Remote endpoints must be externally managed. |
 | `PHONE_REMOTE_WDA_SNAPSHOT_MAX_DEPTH` | *(unset — WDA default 50)* | Opt-in bound on WDA's accessibility snapshot depth (`snapshotMaxDepth`), applied once per WDA session. Try `20`–`30` if an app with an enormous tree (e.g. KakaoTalk, issue #44) kills the runner during `/agent/elements`. |
 | `PHONE_REMOTE_WDA_SNAPSHOT_TIMEOUT_S` | *(unset — WDA default 15)* | Opt-in bound on WDA's snapshot resolution time in seconds (`customSnapshotTimeout`), so an oversized snapshot fails that one request instead of wedging until testmanagerd kills the runner. |
+| `PHONE_REMOTE_ELEMENTS_AFFORDANCES` | *(unset — off)* | Set `1` to enrich `/agent/elements` rows with sparse action affordances derived from the accessibility traits WDA already sends: `actions` (e.g. `["increment","decrement","adjust"]` on sliders/steppers/picker wheels, `["toggle"]` on switches), `selected` (tab bars/segmented controls), and `min`/`max` (slider/stepper range). Off = byte-identical JSON. |
+| `PHONE_REMOTE_ELEMENTS_TRAITS` | *(unset — off)* | Set `1` to also emit each row's verbatim accessibility `traits` names (debugging/forward-compat; most duplicate `kind`). |
 | `PHONE_REMOTE_IDLE_RELEASE_SECS` | `300` | After this many seconds without agent activity or a live viewer, stop the WDA runner so the phone is free for hands-on use. Reconnect starts it again; unlock the phone if required. Set `0` to keep WDA running. |
 | `PHONE_REMOTE_CF_TURN_KEY_ID` / `_API_TOKEN` | — | Legacy mirror/WebRTC Cloudflare TURN credentials. Not used by the direct MJPEG path. |
 | `PHONE_REMOTE_TURN_URLS` / `_USERNAME` / `_CREDENTIAL` | — | Legacy mirror/WebRTC static TURN credentials. |
@@ -275,6 +277,19 @@ field's contents directly through WDA (clear-then-type; empty string clears), an
 `scroll` with `element`+`snapshot` keeps both gesture endpoints inside that element's
 rectangle so a list scrolls without straying into a neighboring scroll view. Both are
 snapshot-bound and fail closed exactly like indexed taps.
+`perform` (`{"type":"perform","element":N,"snapshot":"…","action":"…"}`) invokes a
+named affordance on a snapshot-bound element through WDA's element-scoped routes:
+`increment`/`decrement` (picker wheels, steppers, sliders), `adjust` (set a picker
+wheel's value, or a slider's normalized 0–1 position, via `"value"`), `toggle`
+(switches), `menu` (long-press context menu, optional `duration_ms`), `double_tap`,
+`two_finger_tap`, `scroll_to_visible`, `pinch` (`scale`, optional `velocity`),
+`rotate` (`rotation` radians, optional `velocity`), and `force_press` (optional
+`pressure`+`duration_ms`). An unknown action name returns
+`422 unsupported_perform_action` without dispatching; an element that cannot carry
+the action returns `invalid_element_target`. With
+`PHONE_REMOTE_ELEMENTS_AFFORDANCES=1`, `/agent/elements` rows advertise their
+non-default actions (plus `selected` and `min`/`max`) so an agent can discover them
+without vision.
 `POST /agent/input?return=delta` (optionally `&since=<snapshot>&settle_ms=<ms>`)
 settles after an applied action and returns `snapshot` plus a `delta` against the
 baseline (or full `elements` when no baseline is cached) in the same response —

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -3354,8 +3354,33 @@ async fn perform_snapshot_element(
     if action == "toggle" {
         return match &element_id {
             None => {
-                let (x, y) = element_center(row).ok_or(SnapshotElementTapError::InvalidTarget)?;
-                w.tap_point(x, y).await.map_err(after_dispatch)
+                // A synthesized coordinate tap at the switch's center is
+                // ACKed but does not flip stock Settings switches on iOS 27
+                // (hardware-verified); only an XCUIElement click does. Match
+                // the semantic-less row onto its live element by geometry:
+                // enumerate on-screen Switch elements and pick the one whose
+                // frame equals the row's rect.
+                let candidates = w
+                    .find_elements("class chain", "**/XCUIElementTypeSwitch")
+                    .await
+                    .map_err(SnapshotElementTapError::BeforeDispatch)?;
+                let mut matched = None;
+                for candidate in &candidates {
+                    if let Ok(rect) = w.element_rect(candidate).await {
+                        let close = rect
+                            .iter()
+                            .zip(row.rect.iter())
+                            .all(|(a, b)| (a - b).abs() <= 2.0);
+                        if close {
+                            if matched.is_some() {
+                                return Err(SnapshotElementTapError::Ambiguous);
+                            }
+                            matched = Some(candidate.clone());
+                        }
+                    }
+                }
+                let matched = matched.ok_or(SnapshotElementTapError::NotFound)?;
+                w.click_element(&matched).await.map_err(after_dispatch)
             }
             Some(element_id) => {
                 // A labeled Switch row is usually the full-row wrapper; the

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -2895,6 +2895,10 @@ enum WdaControlOutcome {
     Applied,
     NotSent,
     Unsupported,
+    /// A `perform` action name outside the allowlist. Terminal like
+    /// `Unsupported`, but with its own error code so an agent can tell "this
+    /// verb does not exist" from "this control message shape is unknown".
+    UnsupportedPerformAction,
     InvalidElementSnapshot,
     StaleElementSnapshot,
     ElementNotFound,
@@ -3259,6 +3263,247 @@ async fn set_value_snapshot_element(
     })
 }
 
+/// The closed `perform` action vocabulary (fail-closed allowlist): named
+/// affordances on a snapshot-bound element that have no coordinate-verb home.
+/// A name outside this list is `unsupported_perform_action`, never a guess.
+const PERFORM_ACTION_NAMES: [&str; 11] = [
+    "increment",
+    "decrement",
+    "adjust",
+    "toggle",
+    "menu",
+    "double_tap",
+    "two_finger_tap",
+    "scroll_to_visible",
+    "pinch",
+    "rotate",
+    "force_press",
+];
+
+/// Whether the matched row can carry a `perform` action at all. Gestures are
+/// universal; the value-shaped verbs are limited to kinds WDA can actually
+/// drive (a plain Button cannot `increment`), surfacing as
+/// `invalid_element_target` without any dispatch.
+fn perform_action_kind_permitted(action: &str, row: &crate::wda::ElementRow) -> bool {
+    match action {
+        "increment" | "decrement" => {
+            matches!(row.kind.as_str(), "PickerWheel" | "Stepper" | "Slider")
+        }
+        "adjust" => matches!(row.kind.as_str(), "PickerWheel" | "Slider"),
+        "toggle" => {
+            row.kind == "Switch"
+                || row
+                    .actions
+                    .as_ref()
+                    .is_some_and(|actions| actions.iter().any(|action| action == "toggle"))
+        }
+        _ => true,
+    }
+}
+
+/// Parse a slider row's current `value` into WDA's normalized 0..1 position.
+/// WDA reports sliders as a percent string (`"45%"`) or a bare fraction.
+fn slider_normalized_position(value: Option<&str>) -> Option<f64> {
+    let value = value?.trim();
+    let position = match value.strip_suffix('%') {
+        Some(percent) => percent.trim().parse::<f64>().ok()? / 100.0,
+        None => value.parse::<f64>().ok()?,
+    };
+    (position.is_finite() && (0.0..=1.0).contains(&position)).then_some(position)
+}
+
+/// `{"type":"perform","element":N,"snapshot":"…","action":"…"}` — invoke a
+/// named affordance on a snapshot-bound element through WDA's element-scoped
+/// routes (the caller has already checked the action against
+/// [`PERFORM_ACTION_NAMES`]). Reuses the whole fail-closed pipeline: snapshot
+/// token check, semantic re-resolution, and the 404 → `NotFound` remap on
+/// every post-resolution route.
+async fn perform_snapshot_element(
+    w: &mut crate::wda::WdaClient,
+    value: &serde_json::Value,
+) -> Result<(), SnapshotElementTapError> {
+    let action = value
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(SnapshotElementTapError::Invalid)?
+        .to_string();
+    let (rows, index) = fetch_snapshot_row(w, value).await?;
+    let row = &rows[index];
+    if !perform_action_kind_permitted(&action, row) {
+        return Err(SnapshotElementTapError::InvalidTarget);
+    }
+    let element_id = resolve_snapshot_row_element(w, row).await?;
+    let after_dispatch = |error: anyhow::Error| {
+        if wda_error_is_missing_element(&error) {
+            SnapshotElementTapError::NotFound
+        } else {
+            SnapshotElementTapError::AfterDispatch(error)
+        }
+    };
+    match action.as_str() {
+        "increment" | "decrement" => match row.kind.as_str() {
+            "PickerWheel" => {
+                let order = if action == "increment" {
+                    "next"
+                } else {
+                    "previous"
+                };
+                w.pickerwheel_select(&element_id, order, 0.2)
+                    .await
+                    .map_err(after_dispatch)
+            }
+            "Stepper" => {
+                // A Stepper has no single WDA primitive; its two child
+                // Buttons carry the affordance. Their labels are localized by
+                // iOS ("Increment"/"Decrement" on English devices).
+                let label = if action == "increment" {
+                    "Increment"
+                } else {
+                    "Decrement"
+                };
+                let buttons = w
+                    .find_elements_from(
+                        &element_id,
+                        "class chain",
+                        &format!("**/XCUIElementTypeButton[`label == \"{label}\"`]"),
+                    )
+                    .await
+                    .map_err(SnapshotElementTapError::BeforeDispatch)?;
+                let button = match buttons.as_slice() {
+                    [] => return Err(SnapshotElementTapError::NotFound),
+                    [button] => button.clone(),
+                    _ => return Err(SnapshotElementTapError::Ambiguous),
+                };
+                w.click_element(&button).await.map_err(after_dispatch)
+            }
+            "Slider" => {
+                // No native slider increment: read the current normalized
+                // position from the snapshot row, step 10% of the range, and
+                // let WDA's adjustToNormalizedSliderPosition land it.
+                let position = slider_normalized_position(row.value.as_deref())
+                    .ok_or(SnapshotElementTapError::InvalidTarget)?;
+                let step = if action == "increment" { 0.1 } else { -0.1 };
+                let target = (position + step).clamp(0.0, 1.0);
+                w.adjust_element_value(&element_id, &format!("{target:.3}"))
+                    .await
+                    .map_err(after_dispatch)
+            }
+            _ => Err(SnapshotElementTapError::InvalidTarget),
+        },
+        "adjust" => {
+            let target = value
+                .get("value")
+                .and_then(serde_json::Value::as_str)
+                .ok_or(SnapshotElementTapError::Invalid)?;
+            if row.kind == "Slider"
+                && !target
+                    .trim()
+                    .parse::<f64>()
+                    .is_ok_and(|position| position.is_finite() && (0.0..=1.0).contains(&position))
+            {
+                // A slider adjust is a normalized 0..1 position by contract;
+                // anything else would silently clamp on-device.
+                return Err(SnapshotElementTapError::InvalidTarget);
+            }
+            w.adjust_element_value(&element_id, target)
+                .await
+                .map_err(after_dispatch)
+        }
+        "toggle" => w.click_element(&element_id).await.map_err(after_dispatch),
+        "menu" => {
+            // The element-scoped secondary-action surface on iOS IS the
+            // long-press context menu.
+            let duration_ms = value
+                .get("duration_ms")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(600);
+            let duration_s = (duration_ms as f64 / 1000.0).clamp(0.3, 2.0);
+            w.touch_and_hold_element(&element_id, duration_s)
+                .await
+                .map_err(after_dispatch)
+        }
+        "double_tap" => w
+            .double_tap_element(&element_id)
+            .await
+            .map_err(after_dispatch),
+        "two_finger_tap" => w
+            .two_finger_tap_element(&element_id)
+            .await
+            .map_err(after_dispatch),
+        "scroll_to_visible" => w
+            .scroll_element_to_visible(&element_id)
+            .await
+            .map_err(after_dispatch),
+        "pinch" => {
+            let scale = value
+                .get("scale")
+                .and_then(serde_json::Value::as_f64)
+                .filter(|scale| scale.is_finite() && *scale > 0.0 && *scale <= 10.0)
+                .ok_or(SnapshotElementTapError::Invalid)?;
+            let velocity = value
+                .get("velocity")
+                .and_then(serde_json::Value::as_f64)
+                .filter(|velocity| {
+                    velocity.is_finite() && *velocity != 0.0 && velocity.abs() <= 10.0
+                })
+                .unwrap_or(if scale >= 1.0 { 1.0 } else { -1.0 });
+            w.pinch_element(&element_id, scale, velocity)
+                .await
+                .map_err(after_dispatch)
+        }
+        "rotate" => {
+            let rotation = value
+                .get("rotation")
+                .and_then(serde_json::Value::as_f64)
+                .filter(|rotation| {
+                    rotation.is_finite()
+                        && *rotation != 0.0
+                        && rotation.abs() <= std::f64::consts::TAU
+                })
+                .ok_or(SnapshotElementTapError::Invalid)?;
+            let velocity = value
+                .get("velocity")
+                .and_then(serde_json::Value::as_f64)
+                .filter(|velocity| {
+                    velocity.is_finite() && *velocity != 0.0 && velocity.abs() <= 10.0
+                })
+                .unwrap_or_else(|| rotation.signum());
+            w.rotate_element(&element_id, rotation, velocity)
+                .await
+                .map_err(after_dispatch)
+        }
+        "force_press" => {
+            let pressure = match value.get("pressure") {
+                None => None,
+                Some(pressure) => Some(
+                    pressure
+                        .as_f64()
+                        .filter(|pressure| {
+                            pressure.is_finite() && *pressure > 0.0 && *pressure <= 5.0
+                        })
+                        .ok_or(SnapshotElementTapError::Invalid)?,
+                ),
+            };
+            let duration_s = match value.get("duration_ms") {
+                None => None,
+                Some(duration) => Some(
+                    duration
+                        .as_u64()
+                        .filter(|duration| *duration > 0 && *duration <= 10_000)
+                        .ok_or(SnapshotElementTapError::Invalid)? as f64
+                        / 1000.0,
+                ),
+            };
+            w.force_touch_element(&element_id, pressure, duration_s)
+                .await
+                .map_err(after_dispatch)
+        }
+        // The caller allowlists names before dispatch; anything else here is
+        // a programming error, and failing closed beats acting.
+        _ => Err(SnapshotElementTapError::Invalid),
+    }
+}
+
 /// Shared swipe-travel curve: how far a scroll gesture actually moves for a
 /// requested delta `d` along an axis of the given size.
 fn swipe_travel(d: f64, axis: f64) -> f64 {
@@ -3472,6 +3717,22 @@ async fn wda_control_with_client(
         "set_value" => {
             let result = set_value_snapshot_element(w, v).await;
             match snapshot_element_outcome(result, w, "control set_value") {
+                Ok(result) => result,
+                Err(outcome) => return outcome,
+            }
+        }
+        "perform" => {
+            // Fail closed on the verb BEFORE touching the device: an unknown
+            // action name can never become a dispatch.
+            if !v
+                .get("action")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|action| PERFORM_ACTION_NAMES.contains(&action))
+            {
+                return WdaControlOutcome::UnsupportedPerformAction;
+            }
+            let result = perform_snapshot_element(w, v).await;
+            match snapshot_element_outcome(result, w, "control perform") {
                 Ok(result) => result,
                 Err(outcome) => return outcome,
             }
@@ -3714,6 +3975,20 @@ fn ambiguous_element_response() -> Response {
 fn invalid_element_target_response() -> Response {
     element_resolution_response(
         r#"{"ok":false,"error":"invalid_element_target","outcome":"not_sent","retry_safe":true,"hint":"the matched element has no finite positive-size hit target; refresh /agent/elements and choose another locator"}"#,
+    )
+}
+
+fn unsupported_perform_action_response() -> Response {
+    // retry_safe:false mirrors unsupported_control: retrying the identical
+    // input cannot succeed.
+    with_security_headers(
+        Response::builder()
+            .status(StatusCode::UNPROCESSABLE_ENTITY)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                r#"{"ok":false,"error":"unsupported_perform_action","outcome":"not_sent","retry_safe":false,"hint":"supported perform actions: increment, decrement, adjust, toggle, menu, double_tap, two_finger_tap, scroll_to_visible, pinch, rotate, force_press"}"#,
+            ))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
     )
 }
 
@@ -4063,6 +4338,9 @@ async fn direct_control(
     }
     if outcome == WdaControlOutcome::InvalidElementTarget {
         return invalid_element_target_response();
+    }
+    if outcome == WdaControlOutcome::UnsupportedPerformAction {
+        return unsupported_perform_action_response();
     }
     with_security_headers(
         Response::builder()
@@ -4416,6 +4694,107 @@ fn validate_agent_action_value(
                     .is_some_and(|column| column.as_u64().is_none_or(|value| value > 20))
             {
                 return invalid("picker needs a value up to 500 characters and column 0 to 20");
+            }
+        }
+        "perform" => {
+            if action
+                .get("element")
+                .and_then(serde_json::Value::as_u64)
+                .is_none()
+                || !action
+                    .get("snapshot")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|snapshot| !snapshot.is_empty() && snapshot.chars().count() <= 200)
+            {
+                return invalid("perform needs a non-negative element and snapshot");
+            }
+            let Some(name) = action
+                .get("action")
+                .and_then(serde_json::Value::as_str)
+                .filter(|name| PERFORM_ACTION_NAMES.contains(name))
+            else {
+                return invalid("perform action name is unsupported");
+            };
+            match action.get("value") {
+                Some(value) if name == "adjust" => {
+                    if !value
+                        .as_str()
+                        .is_some_and(|value| !value.is_empty() && value.chars().count() <= 500)
+                    {
+                        return invalid("perform adjust value must contain 1 to 500 characters");
+                    }
+                }
+                Some(_) => return invalid("perform value is only accepted with action adjust"),
+                None if name == "adjust" => {
+                    return invalid("perform adjust requires a value");
+                }
+                None => {}
+            }
+            if let Some(duration) = action.get("duration_ms") {
+                if !matches!(name, "menu" | "force_press") {
+                    return invalid(
+                        "perform duration_ms is only accepted with menu or force_press",
+                    );
+                }
+                if duration
+                    .as_u64()
+                    .is_none_or(|value| value == 0 || value > 10_000)
+                {
+                    return invalid("perform duration_ms must be 1 to 10000");
+                }
+            }
+            match action.get("scale") {
+                Some(scale) => {
+                    if name != "pinch" {
+                        return invalid("perform scale is only accepted with pinch");
+                    }
+                    if !scale
+                        .as_f64()
+                        .is_some_and(|scale| scale.is_finite() && scale > 0.0 && scale <= 10.0)
+                    {
+                        return invalid("perform pinch scale must be above 0 and at most 10");
+                    }
+                }
+                None if name == "pinch" => return invalid("perform pinch requires a scale"),
+                None => {}
+            }
+            match action.get("rotation") {
+                Some(rotation) => {
+                    if name != "rotate" {
+                        return invalid("perform rotation is only accepted with rotate");
+                    }
+                    if !rotation.as_f64().is_some_and(|rotation| {
+                        rotation.is_finite()
+                            && rotation != 0.0
+                            && rotation.abs() <= std::f64::consts::TAU
+                    }) {
+                        return invalid(
+                            "perform rotate rotation must be non-zero within 2*pi radians",
+                        );
+                    }
+                }
+                None if name == "rotate" => return invalid("perform rotate requires a rotation"),
+                None => {}
+            }
+            if let Some(velocity) = action.get("velocity") {
+                if !matches!(name, "pinch" | "rotate") {
+                    return invalid("perform velocity is only accepted with pinch or rotate");
+                }
+                if !velocity.as_f64().is_some_and(|velocity| {
+                    velocity.is_finite() && velocity != 0.0 && velocity.abs() <= 10.0
+                }) {
+                    return invalid("perform velocity must be non-zero within 10");
+                }
+            }
+            if let Some(pressure) = action.get("pressure") {
+                if name != "force_press" {
+                    return invalid("perform pressure is only accepted with force_press");
+                }
+                if !pressure.as_f64().is_some_and(|pressure| {
+                    pressure.is_finite() && pressure > 0.0 && pressure <= 5.0
+                }) {
+                    return invalid("perform pressure must be above 0 and at most 5");
+                }
             }
         }
         _ => return invalid(&format!("has unsupported type {typ:?}")),
@@ -4807,6 +5186,12 @@ async fn agent_actions(
                             "unsupported_control",
                             "not_sent",
                             true,
+                        ),
+                        WdaControlOutcome::UnsupportedPerformAction => (
+                            StatusCode::UNPROCESSABLE_ENTITY,
+                            "unsupported_perform_action",
+                            "not_sent",
+                            false,
                         ),
                         WdaControlOutcome::InvalidElementSnapshot => (
                             StatusCode::BAD_REQUEST,
@@ -5501,6 +5886,7 @@ async fn agent_input(
                     ))
                     .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
             ),
+            WdaControlOutcome::UnsupportedPerformAction => unsupported_perform_action_response(),
             WdaControlOutcome::InvalidElementSnapshot => invalid_element_snapshot_response(),
             WdaControlOutcome::StaleElementSnapshot => stale_element_snapshot_response(),
             WdaControlOutcome::ElementNotFound => element_not_found_response(),
@@ -6452,6 +6838,7 @@ mod tests {
             accessible: Some(true),
             focused: None,
             placeholder: None,
+            ..Default::default()
         }];
         let mut changed = vec![crate::wda::ElementRow {
             kind: "Button".to_string(),
@@ -6465,6 +6852,7 @@ mod tests {
             accessible: Some(true),
             focused: None,
             placeholder: None,
+            ..Default::default()
         }];
 
         let snapshot = element_snapshot_id(&first).unwrap();
@@ -6488,6 +6876,7 @@ mod tests {
             accessible: None,
             focused: None,
             placeholder: None,
+            ..Default::default()
         }
     }
 
@@ -6651,6 +7040,146 @@ mod tests {
     }
 
     #[test]
+    fn validate_perform_requires_snapshot_binding_and_known_action() {
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"increment"})
+        )
+        .is_ok());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"menu","duration_ms":1200})
+        )
+        .is_ok());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"adjust","value":"0.7"})
+        )
+        .is_ok());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"pinch","scale":2.0,"velocity":1.5})
+        )
+        .is_ok());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"rotate","rotation":1.57})
+        )
+        .is_ok());
+
+        // Snapshot binding is mandatory (same contract as set_value).
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","snapshot":"abc","action":"increment"})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"action":"increment"})
+        )
+        .is_err());
+        // Unknown verbs fail closed at validation, matching the runtime's
+        // unsupported_perform_action.
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"levitate"})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc"})
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_perform_scopes_parameters_to_their_actions() {
+        // value is exclusive to adjust — required there, rejected elsewhere.
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"adjust"})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"increment","value":"5"})
+        )
+        .is_err());
+        let oversized = "字".repeat(501);
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"adjust","value":oversized})
+        )
+        .is_err());
+        // duration_ms only for menu/force_press, bounded.
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"double_tap","duration_ms":500})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"menu","duration_ms":10_001})
+        )
+        .is_err());
+        // pinch requires a bounded scale; rotate a bounded non-zero rotation.
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"pinch"})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"pinch","scale":0.0})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"rotate","rotation":0.0})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"menu","scale":2.0})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"toggle","velocity":1.0})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"menu","pressure":1.0})
+        )
+        .is_err());
+        assert!(validate_action(
+            serde_json::json!({"type":"perform","element":4,"snapshot":"abc","action":"force_press","pressure":0.8,"duration_ms":900})
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn perform_kind_gating_limits_value_verbs_to_drivable_kinds() {
+        let row = |kind: &str| crate::wda::ElementRow {
+            kind: kind.to_string(),
+            label: "目标".to_string(),
+            rect: [10.0, 20.0, 80.0, 44.0],
+            depth: 2,
+            ..Default::default()
+        };
+        for kind in ["PickerWheel", "Stepper", "Slider"] {
+            assert!(perform_action_kind_permitted("increment", &row(kind)));
+            assert!(perform_action_kind_permitted("decrement", &row(kind)));
+        }
+        assert!(!perform_action_kind_permitted("increment", &row("Button")));
+        assert!(perform_action_kind_permitted("adjust", &row("Slider")));
+        assert!(perform_action_kind_permitted("adjust", &row("PickerWheel")));
+        assert!(!perform_action_kind_permitted("adjust", &row("Cell")));
+        assert!(perform_action_kind_permitted("toggle", &row("Switch")));
+        assert!(!perform_action_kind_permitted("toggle", &row("Button")));
+        // A ToggleButton-trait Button carries toggle through its derived
+        // actions when the affordances flag populated them.
+        let mut toggle_button = row("Button");
+        toggle_button.actions = Some(vec!["toggle".to_string()]);
+        assert!(perform_action_kind_permitted("toggle", &toggle_button));
+        // Gesture verbs stay universal.
+        for action in ["menu", "double_tap", "two_finger_tap", "scroll_to_visible"] {
+            assert!(perform_action_kind_permitted(action, &row("Cell")));
+        }
+    }
+
+    #[test]
+    fn slider_position_parses_percent_and_fraction_only() {
+        assert_eq!(slider_normalized_position(Some("45%")), Some(0.45));
+        assert_eq!(slider_normalized_position(Some("0.7")), Some(0.7));
+        assert_eq!(slider_normalized_position(Some(" 100 %")), Some(1.0));
+        assert_eq!(slider_normalized_position(Some("37")), None); // ambiguous scale
+        assert_eq!(slider_normalized_position(Some("garbage")), None);
+        assert_eq!(slider_normalized_position(None), None);
+    }
+
+    #[test]
     fn locator_wda_query_uses_element_clickable_predicate_fields() {
         let locator = AgentElementLocator {
             label: Some("保存到“文件”".to_string()),
@@ -6705,6 +7234,7 @@ mod tests {
             accessible: Some(true),
             focused: Some(false),
             placeholder: None,
+            ..Default::default()
         };
 
         let locator = snapshot_row_locator(&row).unwrap();
@@ -6728,6 +7258,7 @@ mod tests {
             accessible: None,
             focused: None,
             placeholder: None,
+            ..Default::default()
         };
 
         assert!(snapshot_row_locator(&row).is_none());
@@ -6748,6 +7279,7 @@ mod tests {
                 accessible: None,
                 focused: None,
                 placeholder: None,
+                ..Default::default()
             },
             crate::wda::ElementRow {
                 kind: "TextField".to_string(),
@@ -6761,6 +7293,7 @@ mod tests {
                 accessible: Some(true),
                 focused: Some(true),
                 placeholder: Some("搜索交易".to_string()),
+                ..Default::default()
             },
         ];
         let expect = AgentUiExpectation {

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -3332,7 +3332,18 @@ async fn perform_snapshot_element(
     if !perform_action_kind_permitted(&action, row) {
         return Err(SnapshotElementTapError::InvalidTarget);
     }
-    let element_id = resolve_snapshot_row_element(w, row).await?;
+    // Hardware reality (stock Settings, iOS 27): the ACTUAL UISwitch is a
+    // semantic-less row (empty label, no identifier) sitting beside a labeled
+    // full-row accessibility wrapper whose element-click lands on the row
+    // middle and toggles nothing. So `toggle` must work without a semantic
+    // locator: fall back to the same snapshot-bound coordinate tap that
+    // `tap` uses for semantic-less rows. Every other perform verb still
+    // requires the semantic resolution.
+    let element_id = match resolve_snapshot_row_element(w, row).await {
+        Ok(element_id) => Some(element_id),
+        Err(SnapshotElementTapError::InvalidTarget) if action == "toggle" => None,
+        Err(error) => return Err(error),
+    };
     let after_dispatch = |error: anyhow::Error| {
         if wda_error_is_missing_element(&error) {
             SnapshotElementTapError::NotFound
@@ -3340,6 +3351,29 @@ async fn perform_snapshot_element(
             SnapshotElementTapError::AfterDispatch(error)
         }
     };
+    if action == "toggle" {
+        return match &element_id {
+            None => {
+                let (x, y) = element_center(row).ok_or(SnapshotElementTapError::InvalidTarget)?;
+                w.tap_point(x, y).await.map_err(after_dispatch)
+            }
+            Some(element_id) => {
+                // A labeled Switch row is usually the full-row wrapper; the
+                // clickable control is its (sole) descendant Switch. Prefer
+                // that; fall back to clicking the resolved element itself.
+                let descendants = w
+                    .find_elements_from(element_id, "class chain", "**/XCUIElementTypeSwitch")
+                    .await
+                    .unwrap_or_default();
+                let target = match descendants.as_slice() {
+                    [switch] if switch != element_id => switch,
+                    _ => element_id,
+                };
+                w.click_element(target).await.map_err(after_dispatch)
+            }
+        };
+    }
+    let element_id = element_id.expect("non-toggle actions always resolve or return above");
     match action.as_str() {
         "increment" | "decrement" => match row.kind.as_str() {
             "PickerWheel" => {
@@ -3409,7 +3443,6 @@ async fn perform_snapshot_element(
                 .await
                 .map_err(after_dispatch)
         }
-        "toggle" => w.click_element(&element_id).await.map_err(after_dispatch),
         "menu" => {
             // The element-scoped secondary-action surface on iOS IS the
             // long-press context menu.

--- a/crates/server/src/wda.rs
+++ b/crates/server/src/wda.rs
@@ -1049,6 +1049,28 @@ impl WdaClient {
         Err(last_err.unwrap_or_else(|| anyhow!("element not found: {label}")))
     }
 
+    /// One element's frame in WDA points (`GET .../element/:id/rect`).
+    /// Used to match a semantic-less source-tree row onto its live XCUIElement
+    /// when nothing but geometry identifies it (e.g. a bare `UISwitch`).
+    pub async fn element_rect(&mut self, element_id: &str) -> Result<[f64; 4]> {
+        let sid = self.ensure_session().await?.to_string();
+        let response = self
+            .http
+            .get(format!(
+                "{}/session/{}/element/{}/rect",
+                self.base, sid, element_id
+            ))
+            .send()
+            .await
+            .context("GET element/rect")?;
+        let value = ensure_wda_success(response, "GET element/rect").await?;
+        let g = |k: &str| value.get(k).and_then(serde_json::Value::as_f64);
+        match (g("x"), g("y"), g("width"), g("height")) {
+            (Some(x), Some(y), Some(w), Some(h)) => Ok([x, y, w, h]),
+            _ => Err(anyhow!("GET element/rect returned bad frame: {value}")),
+        }
+    }
+
     /// Drop the cached session (e.g. after an error that suggests it went
     /// stale); the next call re-creates one via [`Self::ensure_session`].
     pub fn invalidate_session(&mut self) {

--- a/crates/server/src/wda.rs
+++ b/crates/server/src/wda.rs
@@ -351,6 +351,200 @@ impl WdaClient {
         Ok(())
     }
 
+    /// Find ALL elements matching a locator UNDER an already-resolved element
+    /// (`POST .../element/:id/elements`), in document order. Used to address a
+    /// composite control's children (e.g. a Stepper's Increment/Decrement
+    /// buttons) without widening the search to the whole tree.
+    pub async fn find_elements_from(
+        &mut self,
+        element_id: &str,
+        using: &str,
+        value: &str,
+    ) -> Result<Vec<String>> {
+        let sid = self.ensure_session().await?.to_string();
+        let response = self
+            .http
+            .post(format!(
+                "{}/session/{}/element/{}/elements",
+                self.base, sid, element_id
+            ))
+            .json(&serde_json::json!({ "using": using, "value": value }))
+            .send()
+            .await
+            .context("POST element/elements")?;
+        let value = ensure_wda_success(response, "POST element/elements").await?;
+        let elements = value
+            .as_array()
+            .ok_or_else(|| anyhow!("POST element/elements returned non-array value: {value}"))?;
+        Ok(elements
+            .iter()
+            .filter_map(|e| {
+                e.get("ELEMENT")
+                    .or_else(|| e.get("element-6066-11e4-a52e-4f735466cecf"))
+                    .and_then(|x| x.as_str())
+                    .map(String::from)
+            })
+            .collect())
+    }
+
+    /// POST one element-scoped `/wda/element/:id/<command>` gesture. Every
+    /// call sends a JSON body (at least `{}`) because a bodyless POST is
+    /// rejected with 400 by current WDA builds (see [`Self::clear_element`]).
+    async fn post_element_gesture(
+        &mut self,
+        element_id: &str,
+        command: &str,
+        body: serde_json::Value,
+    ) -> Result<()> {
+        let sid = self.ensure_session().await?.to_string();
+        let operation = format!("POST wda/element/{command}");
+        let response = self
+            .http
+            .post(format!(
+                "{}/session/{}/wda/element/{}/{}",
+                self.base, sid, element_id, command
+            ))
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| operation.clone())?;
+        ensure_wda_success(response, &operation).await?;
+        Ok(())
+    }
+
+    /// Long-press an element (`POST .../wda/element/:id/touchAndHold`) — the
+    /// element-scoped context-menu ("secondary action") gesture. WDA computes
+    /// the geometry, so this is immune to stale source-tree rectangles.
+    pub async fn touch_and_hold_element(
+        &mut self,
+        element_id: &str,
+        duration_s: f64,
+    ) -> Result<()> {
+        self.post_element_gesture(
+            element_id,
+            "touchAndHold",
+            serde_json::json!({ "duration": duration_s }),
+        )
+        .await
+    }
+
+    /// Double-tap an element (`POST .../wda/element/:id/doubleTap`).
+    pub async fn double_tap_element(&mut self, element_id: &str) -> Result<()> {
+        self.post_element_gesture(element_id, "doubleTap", serde_json::json!({}))
+            .await
+    }
+
+    /// Two-finger tap an element (`POST .../wda/element/:id/twoFingerTap`).
+    pub async fn two_finger_tap_element(&mut self, element_id: &str) -> Result<()> {
+        self.post_element_gesture(element_id, "twoFingerTap", serde_json::json!({}))
+            .await
+    }
+
+    /// Scroll an element into view (`POST .../wda/element/:id/scrollTo`).
+    pub async fn scroll_element_to_visible(&mut self, element_id: &str) -> Result<()> {
+        self.post_element_gesture(element_id, "scrollTo", serde_json::json!({}))
+            .await
+    }
+
+    /// Pinch an element (`POST .../wda/element/:id/pinch`). `scale` above 1
+    /// zooms in, below 1 zooms out; XCUITest wants `velocity`'s sign to match.
+    pub async fn pinch_element(
+        &mut self,
+        element_id: &str,
+        scale: f64,
+        velocity: f64,
+    ) -> Result<()> {
+        self.post_element_gesture(
+            element_id,
+            "pinch",
+            serde_json::json!({ "scale": scale, "velocity": velocity }),
+        )
+        .await
+    }
+
+    /// Rotate an element (`POST .../wda/element/:id/rotate`). `rotation` is in
+    /// radians; XCUITest wants `velocity`'s sign to match the rotation's.
+    pub async fn rotate_element(
+        &mut self,
+        element_id: &str,
+        rotation: f64,
+        velocity: f64,
+    ) -> Result<()> {
+        self.post_element_gesture(
+            element_id,
+            "rotate",
+            serde_json::json!({ "rotation": rotation, "velocity": velocity }),
+        )
+        .await
+    }
+
+    /// Force-press an element (`POST .../wda/element/:id/forceTouch`). WDA
+    /// treats `pressure` and `duration` as a pair, so a caller providing
+    /// either gets both (defaults: pressure 1.0, duration 0.5 s); providing
+    /// neither sends the plain default force press.
+    pub async fn force_touch_element(
+        &mut self,
+        element_id: &str,
+        pressure: Option<f64>,
+        duration_s: Option<f64>,
+    ) -> Result<()> {
+        let body = if pressure.is_some() || duration_s.is_some() {
+            serde_json::json!({
+                "pressure": pressure.unwrap_or(1.0),
+                "duration": duration_s.unwrap_or(0.5),
+            })
+        } else {
+            serde_json::json!({})
+        };
+        self.post_element_gesture(element_id, "forceTouch", body)
+            .await
+    }
+
+    /// Move a picker wheel one notch (`POST .../wda/pickerwheel/:id/select`).
+    /// `order` is `"next"` (increment) or `"previous"` (decrement); `offset`
+    /// is WDA's tap offset from the wheel's center (0.2 is its documented
+    /// sweet spot for one-notch moves).
+    pub async fn pickerwheel_select(
+        &mut self,
+        element_id: &str,
+        order: &str,
+        offset: f64,
+    ) -> Result<()> {
+        let sid = self.ensure_session().await?.to_string();
+        let response = self
+            .http
+            .post(format!(
+                "{}/session/{}/wda/pickerwheel/{}/select",
+                self.base, sid, element_id
+            ))
+            .json(&serde_json::json!({ "order": order, "offset": offset }))
+            .send()
+            .await
+            .context("POST wda/pickerwheel/select")?;
+        ensure_wda_success(response, "POST wda/pickerwheel/select").await?;
+        Ok(())
+    }
+
+    /// Adjust a wheel/slider by POSTing a BARE `{"value":[…]}` to
+    /// `element/:id/value` — no `text` key, exactly like [`Self::set_picker`]:
+    /// the extra `text` makes WDA keyboard-type instead of calling
+    /// `adjustToPickerWheelValue:` / `adjustToNormalizedSliderPosition:`.
+    pub async fn adjust_element_value(&mut self, element_id: &str, value: &str) -> Result<()> {
+        let sid = self.ensure_session().await?.to_string();
+        let response = self
+            .http
+            .post(format!(
+                "{}/session/{}/element/{}/value",
+                self.base, sid, element_id
+            ))
+            .json(&serde_json::json!({ "value": [value] }))
+            .send()
+            .await
+            .context("POST element/value (adjust)")?;
+        ensure_wda_success(response, "POST element/value (adjust)").await?;
+        Ok(())
+    }
+
     /// Coordinate tap via the W3C Actions API (`POST /session/<id>/actions`, a
     /// touch down-up at the point). Useful when there's no addressable element;
     /// still synthesized on the phone, so no host-cursor contention. Coords are
@@ -905,7 +1099,7 @@ fn snapshot_settings_from_env() -> Option<serde_json::Map<String, serde_json::Va
 }
 
 /// One row of the flattened element tree.
-#[derive(Debug, serde::Serialize, PartialEq)]
+#[derive(Debug, Default, serde::Serialize, PartialEq)]
 pub struct ElementRow {
     /// Element type without the `XCUIElementType` prefix (e.g. `Button`).
     pub kind: String,
@@ -944,6 +1138,29 @@ pub struct ElementRow {
     /// Text-input placeholder when WDA exposes it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub placeholder: Option<String>,
+    /// Derived non-default affordances (`PHONE_REMOTE_ELEMENTS_AFFORDANCES=1`
+    /// only): the named `perform` actions this element supports beyond the
+    /// universal tap/longpress family, from `type` + accessibility traits +
+    /// min/max — e.g. `["increment","decrement","adjust"]`. Emitted only for
+    /// kinds the daemon can actually drive, so plain Buttons/Cells/StaticText
+    /// emit nothing and the default JSON stays byte-identical.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Vec<String>>,
+    /// From the `Selected` accessibility trait (tab bars, segmented controls,
+    /// filter chips); only `true` is emitted. Affordances flag only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected: Option<bool>,
+    /// Slider/Stepper range, parsed from WDA's `minValue`/`maxValue` strings.
+    /// Affordances flag only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    /// Verbatim accessibility trait names (`PHONE_REMOTE_ELEMENTS_TRAITS=1`
+    /// only, for debugging/forward-compat) — most values duplicate `kind`, so
+    /// this is not part of the default or affordances payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traits: Option<Vec<String>>,
 }
 
 fn wda_bool(node: &serde_json::Value, key: &str) -> Option<bool> {
@@ -971,10 +1188,95 @@ fn non_empty_string(node: &serde_json::Value, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// A finite number WDA emits either natively or as an `NSNumber.stringValue`
+/// string (`minValue`/`maxValue` arrive as strings on v9.15.3).
+fn wda_number(node: &serde_json::Value, key: &str) -> Option<f64> {
+    match node.get(key)? {
+        serde_json::Value::Number(value) => value.as_f64(),
+        serde_json::Value::String(value) => value.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+    .filter(|value| value.is_finite())
+}
+
+/// The node's `UIAccessibilityTraits` names, from WDA's comma-separated
+/// `traits` string (e.g. `"Button, Selected"`).
+fn node_traits(node: &serde_json::Value) -> Vec<String> {
+    node.get("traits")
+        .and_then(serde_json::Value::as_str)
+        .map(|traits| {
+            traits
+                .split(',')
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Derive the sparse non-default `perform` affordances for one element.
+///
+/// Only kinds the daemon can actually drive are listed (a bare `Adjustable`
+/// trait on an `Other` row has no reachable WDA increment path, so emitting
+/// it would advertise an action `perform` must refuse). Universal gestures
+/// (tap, longpress/menu, double_tap, swipes) are deliberately NOT listed per
+/// row — `perform` still accepts them everywhere.
+fn derived_actions(
+    kind: &str,
+    traits: &[String],
+    min: Option<f64>,
+    max: Option<f64>,
+) -> Option<Vec<String>> {
+    let actions: &[&str] = match kind {
+        "PickerWheel" | "Slider" => &["increment", "decrement", "adjust"],
+        "Stepper" => &["increment", "decrement"],
+        "Switch" => &["toggle"],
+        // iOS 17+ marks on/off buttons that are not tree-level Switches.
+        _ if traits.iter().any(|name| name == "ToggleButton") => &["toggle"],
+        // A min/max pair on an otherwise untyped control is Stepper-like.
+        _ if min.is_some() && max.is_some() => &["increment", "decrement"],
+        _ => return None,
+    };
+    Some(actions.iter().map(|action| action.to_string()).collect())
+}
+
+/// Opt-in extras for [`flatten_tree`], read from the environment once per
+/// flatten (mirroring the `snapshot_settings_from_env` opt-in pattern). Both
+/// default to off, which keeps the emitted JSON byte-identical.
+#[derive(Debug, Clone, Copy, Default)]
+struct FlattenOptions {
+    /// `PHONE_REMOTE_ELEMENTS_AFFORDANCES=1`: emit sparse `actions`,
+    /// `selected`, `min`, and `max` derived from traits + min/max values.
+    affordances: bool,
+    /// `PHONE_REMOTE_ELEMENTS_TRAITS=1`: emit the verbatim `traits` names.
+    raw_traits: bool,
+}
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| value.trim() == "1")
+}
+
+fn flatten_options_from_env() -> FlattenOptions {
+    FlattenOptions {
+        affordances: env_flag("PHONE_REMOTE_ELEMENTS_AFFORDANCES"),
+        raw_traits: env_flag("PHONE_REMOTE_ELEMENTS_TRAITS"),
+    }
+}
+
 /// Recursively flatten a WDA `/source?format=json` tree, keeping only rows an
 /// agent can act on or learn from: anything with a non-empty label, or an
 /// interactive type. Order is document order (roughly top-to-bottom).
 fn flatten_tree(node: &serde_json::Value, depth: u32, out: &mut Vec<ElementRow>) {
+    flatten_tree_with(node, depth, out, flatten_options_from_env());
+}
+
+fn flatten_tree_with(
+    node: &serde_json::Value,
+    depth: u32,
+    out: &mut Vec<ElementRow>,
+    options: FlattenOptions,
+) {
     const INTERACTIVE: [&str; 11] = [
         "Button",
         "Cell",
@@ -1017,6 +1319,26 @@ fn flatten_tree(node: &serde_json::Value, depth: u32, out: &mut Vec<ElementRow>)
         let visible = wda_bool(node, "isVisible").filter(|value| !value);
         let accessible = wda_bool(node, "isAccessible").filter(|value| *value);
         let focused = wda_bool(node, "isFocused").filter(|value| *value);
+        // Affordance extras (both env-gated; the default daemon parses none of
+        // this and every field stays None → byte-identical serialized rows).
+        let traits = if options.affordances || options.raw_traits {
+            node_traits(node)
+        } else {
+            Vec::new()
+        };
+        let (actions, selected, min, max) = if options.affordances {
+            let min = wda_number(node, "minValue");
+            let max = wda_number(node, "maxValue");
+            (
+                derived_actions(&kind, &traits, min, max),
+                traits.iter().any(|name| name == "Selected").then_some(true),
+                min,
+                max,
+            )
+        } else {
+            (None, None, None, None)
+        };
+        let traits = (options.raw_traits && !traits.is_empty()).then_some(traits);
         out.push(ElementRow {
             kind,
             label,
@@ -1029,11 +1351,16 @@ fn flatten_tree(node: &serde_json::Value, depth: u32, out: &mut Vec<ElementRow>)
             accessible,
             focused,
             placeholder: non_empty_string(node, "placeholderValue"),
+            actions,
+            selected,
+            min,
+            max,
+            traits,
         });
     }
     if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
         for c in children {
-            flatten_tree(c, depth + 1, out);
+            flatten_tree_with(c, depth + 1, out, options);
         }
     }
 }
@@ -1502,5 +1829,175 @@ mod tests {
         assert!(json.get("visible").is_none());
         assert!(json.get("accessible").is_none());
         assert!(json.get("focused").is_none());
+    }
+
+    /// A tree that carries `traits`/`minValue`/`maxValue`; the affordance
+    /// tests below all parse this one fixture.
+    fn affordance_tree() -> serde_json::Value {
+        serde_json::json!({
+            "type": "XCUIElementTypeApplication",
+            "children": [
+                {"type": "XCUIElementTypeSwitch", "label": "Wi-Fi", "value": "1",
+                 "traits": "Button",
+                 "rect": {"x": 300, "y": 100, "width": 51, "height": 31}},
+                {"type": "XCUIElementTypeSlider", "label": "亮度", "value": "45%",
+                 "traits": "Adjustable", "minValue": "0", "maxValue": "1",
+                 "rect": {"x": 20, "y": 200, "width": 380, "height": 30}},
+                {"type": "XCUIElementTypePickerWheel", "label": "", "value": "三月",
+                 "traits": "Adjustable",
+                 "rect": {"x": 40, "y": 300, "width": 120, "height": 200}},
+                {"type": "XCUIElementTypeStepper", "label": "份数",
+                 "traits": "Adjustable", "minValue": "1", "maxValue": "10",
+                 "rect": {"x": 40, "y": 520, "width": 94, "height": 32}},
+                {"type": "XCUIElementTypeButton", "label": "浏览",
+                 "traits": "Button, Selected",
+                 "rect": {"x": 0, "y": 900, "width": 110, "height": 48}},
+                {"type": "XCUIElementTypeButton", "label": "静音",
+                 "traits": "ToggleButton",
+                 "rect": {"x": 120, "y": 900, "width": 110, "height": 48}},
+                {"type": "XCUIElementTypeOther", "label": "自定义调节",
+                 "traits": "Adjustable",
+                 "rect": {"x": 20, "y": 600, "width": 400, "height": 44}}
+            ]
+        })
+    }
+
+    #[test]
+    fn flatten_default_is_byte_identical_with_traits_present() {
+        // With the affordance flags unset (the default in this test process),
+        // a tree carrying traits/minValue/maxValue must serialize exactly like
+        // the same tree without them — existing snapshot-token hashes and
+        // clients see no difference.
+        let with_extras = affordance_tree();
+        let mut without_extras = with_extras.clone();
+        for child in without_extras["children"].as_array_mut().unwrap() {
+            let child = child.as_object_mut().unwrap();
+            child.remove("traits");
+            child.remove("minValue");
+            child.remove("maxValue");
+        }
+
+        let mut rows = Vec::new();
+        flatten_tree(&with_extras, 0, &mut rows);
+        let mut plain_rows = Vec::new();
+        flatten_tree(&without_extras, 0, &mut plain_rows);
+
+        assert_eq!(rows, plain_rows);
+        assert_eq!(
+            serde_json::to_string(&rows).unwrap(),
+            serde_json::to_string(&plain_rows).unwrap()
+        );
+        assert!(!serde_json::to_string(&rows).unwrap().contains("actions"));
+    }
+
+    #[test]
+    fn flatten_with_affordances_derives_actions_selected_and_range() {
+        let mut rows = Vec::new();
+        flatten_tree_with(
+            &affordance_tree(),
+            0,
+            &mut rows,
+            FlattenOptions {
+                affordances: true,
+                raw_traits: false,
+            },
+        );
+        assert_eq!(rows.len(), 7);
+
+        let by_kind = |kind: &str| rows.iter().find(|row| row.kind == kind).unwrap();
+        assert_eq!(
+            by_kind("Switch").actions.as_deref(),
+            Some(&["toggle".to_string()][..])
+        );
+        let slider = by_kind("Slider");
+        assert_eq!(
+            slider.actions.as_deref(),
+            Some(
+                &[
+                    "increment".to_string(),
+                    "decrement".to_string(),
+                    "adjust".to_string()
+                ][..]
+            )
+        );
+        assert_eq!(slider.min, Some(0.0));
+        assert_eq!(slider.max, Some(1.0));
+        assert_eq!(
+            by_kind("PickerWheel").actions.as_deref(),
+            Some(
+                &[
+                    "increment".to_string(),
+                    "decrement".to_string(),
+                    "adjust".to_string()
+                ][..]
+            )
+        );
+        let stepper = by_kind("Stepper");
+        assert_eq!(
+            stepper.actions.as_deref(),
+            Some(&["increment".to_string(), "decrement".to_string()][..])
+        );
+        assert_eq!(stepper.min, Some(1.0));
+        assert_eq!(stepper.max, Some(10.0));
+
+        // Selected trait → state, not an action; the plain tab Button gets
+        // no actions list at all.
+        let tab = rows.iter().find(|row| row.label == "浏览").unwrap();
+        assert_eq!(tab.selected, Some(true));
+        assert_eq!(tab.actions, None);
+
+        // ToggleButton trait on a Button → toggle.
+        let mute = rows.iter().find(|row| row.label == "静音").unwrap();
+        assert_eq!(mute.actions.as_deref(), Some(&["toggle".to_string()][..]));
+        assert_eq!(mute.selected, None);
+
+        // Bare Adjustable on an untyped row has no reachable WDA increment
+        // path — advertise nothing rather than an action perform must refuse.
+        let custom = by_kind("Other");
+        assert_eq!(custom.actions, None);
+
+        // Raw traits stay behind their own flag.
+        assert!(rows.iter().all(|row| row.traits.is_none()));
+    }
+
+    #[test]
+    fn flatten_with_raw_traits_emits_verbatim_names() {
+        let mut rows = Vec::new();
+        flatten_tree_with(
+            &affordance_tree(),
+            0,
+            &mut rows,
+            FlattenOptions {
+                affordances: false,
+                raw_traits: true,
+            },
+        );
+        let tab = rows.iter().find(|row| row.label == "浏览").unwrap();
+        assert_eq!(
+            tab.traits.as_deref(),
+            Some(&["Button".to_string(), "Selected".to_string()][..])
+        );
+        // Traits alone never derive actions/selected/min/max.
+        assert!(rows.iter().all(|row| row.actions.is_none()
+            && row.selected.is_none()
+            && row.min.is_none()
+            && row.max.is_none()));
+        let switch = rows.iter().find(|row| row.kind == "Switch").unwrap();
+        assert_eq!(switch.traits.as_deref(), Some(&["Button".to_string()][..]));
+    }
+
+    #[test]
+    fn wda_number_parses_nsnumber_strings_and_numbers() {
+        let node = serde_json::json!({
+            "minValue": "0.25",
+            "maxValue": 10,
+            "bad": "wide open",
+            "inf": "inf"
+        });
+        assert_eq!(wda_number(&node, "minValue"), Some(0.25));
+        assert_eq!(wda_number(&node, "maxValue"), Some(10.0));
+        assert_eq!(wda_number(&node, "bad"), None);
+        assert_eq!(wda_number(&node, "inf"), None);
+        assert_eq!(wda_number(&node, "missing"), None);
     }
 }

--- a/skills/iphone-use/SKILL.md
+++ b/skills/iphone-use/SKILL.md
@@ -70,7 +70,7 @@ and is not a Direct readiness signal.
 | Call | Purpose |
 |---|---|
 | `GET /agent/status` | `{ok, backend, device_state, screen_state, wda, wda_actionable, wda_locked, drivable, released, hint, setup_blocked_on, setup_phase, setup_message, …}` — gate on **`drivable`** |
-| `GET /agent/elements` | **Direct/WDA UI as text**: `{"snapshot":"…","elements":[{kind,label,identifier?,rect,depth,value?,enabled?,visible?,accessible?,focused?,placeholder?},…]}` — prefer this over screenshots. Indexes and snapshot tokens are valid only for this read. Add `?since=<prior snapshot>` to get `{"snapshot":…,"baseline":…,"delta":{added,changed,removed,unchanged}}` instead of the full tree (much cheaper on multi-step flows; unknown baseline falls back to the full tree) |
+| `GET /agent/elements` | **Direct/WDA UI as text**: `{"snapshot":"…","elements":[{kind,label,identifier?,rect,depth,value?,enabled?,visible?,accessible?,focused?,placeholder?},…]}` — prefer this over screenshots. Indexes and snapshot tokens are valid only for this read. Add `?since=<prior snapshot>` to get `{"snapshot":…,"baseline":…,"delta":{added,changed,removed,unchanged}}` instead of the full tree (much cheaper on multi-step flows; unknown baseline falls back to the full tree). With `PHONE_REMOTE_ELEMENTS_AFFORDANCES=1` on the daemon, rows also carry sparse `actions` (named `perform` affordances), `selected`, and `min`/`max` |
 | `GET /agent/screenshot` | Current phone screen as a device-side PNG; no Mirroring session required |
 | `POST /agent/input` | One action (JSON body, below); requires `X-Phone-Control: 1` |
 | `POST /agent/actions` | One bounded, fail-closed sequence of `action`, `wait_for`, and short `pause` steps; Direct/WDA only; requires `X-Phone-Control: 1` |
@@ -94,6 +94,7 @@ curl -s -H "$AUTH" -H "$MUTATION" -X POST "$HOST/agent/input" -d '{"type":"longp
 curl -s -H "$AUTH" -H "$MUTATION" -X POST "$HOST/agent/input" -d '{"type":"keyboard"}'                     # dismiss the on-screen keyboard
 curl -s -H "$AUTH" -H "$MUTATION" -X POST "$HOST/agent/input" -d '{"type":"set_value","element":5,"snapshot":"…","value":"你好"}'  # write a field directly (clear-then-type; "" clears); no focus tap, no keyboard dance
 curl -s -H "$AUTH" -H "$MUTATION" -X POST "$HOST/agent/input" -d '{"type":"scroll","element":7,"snapshot":"…","dy":120}'          # scroll INSIDE that element's rect — never strays into a neighboring scroll view
+curl -s -H "$AUTH" -H "$MUTATION" -X POST "$HOST/agent/input" -d '{"type":"perform","element":9,"snapshot":"…","action":"increment"}'  # named affordance on that element: increment|decrement (wheel/stepper/slider), adjust (+"value"), toggle, menu (long-press menu), double_tap, two_finger_tap, scroll_to_visible, pinch, rotate, force_press
 ```
 
 **Halve the round trips**: `POST /agent/input?return=delta` makes an applied


### PR DESCRIPTION
Track C of the paradigm work (design: PR #52, `docs/research/2026-09-action-affordances.md`). All additive; default JSON byte-identical (dedicated test).

- `PHONE_REMOTE_ELEMENTS_AFFORDANCES=1` → sparse `actions`/`selected`/`min`/`max` on `/agent/elements` rows, derived from the `traits`/`minValue`/`maxValue` WDA already emits (and `flatten_tree` previously discarded). `PHONE_REMOTE_ELEMENTS_TRAITS=1` exposes raw traits separately.
- New snapshot-bound action `{"type":"perform","element":N,"snapshot":"…","action":"…"}` riding the existing resolve pipeline (same fail-closed taxonomy incl. the stale-404→element_not_found remap; new `unsupported_perform_action` 422). Actions: touch_and_hold / double_tap / two_finger_tap / scroll_to_visible / pinch / rotate / force_touch / increment / decrement / toggle / adjust / pickerwheel next-previous. Kind-gated (`increment` on a Button → `invalid_element_target`); `/agent/actions` batch validation included.
- `set_value` behavior deliberately untouched (design §2.3 tightening skipped — would change existing behavior); Slider/PickerWheel adjustment is formalized under `perform:"adjust"` instead.

Tests: 242 server tests green (new: flag on/off byte-identity, NSNumber-string parsing, perform validation, kind gating, slider position math); clippy/fmt clean. Independently re-verified by the coordinating session.

**Hardware validation pending (blocking merge):**
- [ ] Stepper inc/dec child-button resolution on a Chinese-locale phone (labels are localized — may need position fallback)
- [ ] pickerwheel next/previous one-notch offset; slider adjust landing accuracy
- [ ] force_touch pressure/duration semantics on WDA 9.15.3
- [ ] ToggleButton/Selected traits presence on this device's runner build
- [ ] snapshot/delta stability with affordances flag on across real screens

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named actions for snapshot-bound elements, including tapping, toggling, scrolling, pinching, rotating, pressing, and value adjustments.
  * Element listings can optionally include supported actions, selection state, numeric ranges, and accessibility traits.
  * Added configuration options to enable element affordance and trait metadata.
  * Improved toggle support for switches without labels or identifiers.
* **Documentation**
  * Updated API documentation with the new input action, configuration settings, supported actions, and examples.
* **Bug Fixes**
  * Improved validation and error reporting for unsupported or malformed actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->