### PR TITLE
feat(agent): ax_stats usability signals + vision-fallback operating procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The bundled web and MCP clients add the header automatically.
 | `GET` / `POST` | `/agent/inbox` | GET safely peeks at the legacy Shortcuts result queue. POST requires bearer auth plus the mutation header and appends one result. |
 | `POST` | `/agent/inbox/drain` | Requires bearer auth plus the mutation header; atomically returns and clears the queued results. |
 | `GET` | `/agent/screenshot` | Current phone screen as PNG from the on-device path. |
-| `GET` | `/agent/elements` | Flattened WDA accessibility tree plus an ephemeral `snapshot` token. `?since=<snapshot>` answers with a `delta` (`added`/`changed`/`removed`/`unchanged`) against a still-cached prior tree instead of the full list; an unknown baseline falls back to the full tree. Missing/busy WDA returns `503`; a failed source retry returns `502`, never a misleading `200` empty tree. |
+| `GET` | `/agent/elements` | Flattened WDA accessibility tree plus an ephemeral `snapshot` token. `?since=<snapshot>` answers with a `delta` (`added`/`changed`/`removed`/`unchanged`) against a still-cached prior tree instead of the full list; an unknown baseline falls back to the full tree. Both shapes include a read-only `ax_stats` block (`n`, `n_interactive`, `labeled_frac`, `coverage`, `container_only`, `max_depth`) so clients can judge tree usability before falling back to vision. Missing/busy WDA returns `503`; a failed source retry returns `502`, never a misleading `200` empty tree. |
 
 Gate actions on **`drivable`** and, for direct mode, require
 `backend:"direct"` plus `wda_actionable:true`. `phone_target`, `mirror_state`, and

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -2911,6 +2911,131 @@ fn element_snapshot_id(rows: &[crate::wda::ElementRow]) -> anyhow::Result<String
     Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(Sha256::digest(encoded)))
 }
 
+/// Read-only usability statistics for one flattened element tree, reported as
+/// the additive `ax_stats` block on `/agent/elements` responses.
+///
+/// The daemon computes and reports; it never decides. Whether the tree is
+/// "usable" is policy that belongs to the calling agent/skill (see the
+/// visual-fallback design: sparse game/canvas trees vs. healthy dense trees).
+/// Pure function of rows the response already serializes — it never touches
+/// [`element_snapshot_id`], which keeps hashing ROWS only, so `ax_stats` can
+/// never perturb snapshot tokens.
+#[derive(Debug, PartialEq, serde::Serialize)]
+struct AxStats {
+    /// Total serialized rows.
+    n: usize,
+    /// Rows whose `kind` is one of [`crate::wda::INTERACTIVE_KINDS`].
+    n_interactive: usize,
+    /// Interactive rows with a non-empty label ÷ `n_interactive`; `1.0` when
+    /// there are no interactive rows (nothing is missing a label).
+    labeled_frac: f64,
+    /// Union area of all rects, clipped to the screen, ÷ screen area.
+    /// `null` when the screen size is unknown. Note a single full-screen
+    /// container makes this ≈ 1.0 while being useless — gate any coverage
+    /// judgment on `n_interactive` and `container_only` first.
+    coverage: Option<f64>,
+    /// Every row's `kind` is a pure container/decoration kind
+    /// (`Application`, `Window`, `Other`, `Image`). Vacuously true when the
+    /// tree is empty.
+    container_only: bool,
+    /// Maximum row depth; `0` for an empty tree.
+    max_depth: u32,
+}
+
+/// Compute [`AxStats`] for one flattened tree. `screen` is WDA's point-space
+/// window size when the lookup succeeded (its failure is non-fatal for the
+/// endpoint, so coverage degrades to `null` rather than failing the read).
+fn ax_stats(rows: &[crate::wda::ElementRow], screen: Option<(f64, f64)>) -> AxStats {
+    const CONTAINER_KINDS: [&str; 4] = ["Application", "Window", "Other", "Image"];
+
+    let interactive: Vec<&crate::wda::ElementRow> = rows
+        .iter()
+        .filter(|row| crate::wda::INTERACTIVE_KINDS.contains(&row.kind.as_str()))
+        .collect();
+    let labeled_frac = if interactive.is_empty() {
+        1.0
+    } else {
+        interactive
+            .iter()
+            .filter(|row| !row.label.is_empty())
+            .count() as f64
+            / interactive.len() as f64
+    };
+    let coverage = screen
+        .filter(|(width, height)| {
+            width.is_finite() && height.is_finite() && *width > 0.0 && *height > 0.0
+        })
+        .map(|(width, height)| {
+            let rects: Vec<[f64; 4]> = rows.iter().map(|row| row.rect).collect();
+            rect_union_area_clipped(&rects, width, height) / (width * height)
+        });
+    AxStats {
+        n: rows.len(),
+        n_interactive: interactive.len(),
+        labeled_frac,
+        coverage,
+        container_only: rows
+            .iter()
+            .all(|row| CONTAINER_KINDS.contains(&row.kind.as_str())),
+        max_depth: rows.iter().map(|row| row.depth).max().unwrap_or(0),
+    }
+}
+
+/// Area of the union of `[x, y, w, h]` rects, each clipped to
+/// `[0, screen_width] × [0, screen_height]`. Overlaps are counted once
+/// (x-coordinate sweep with a 1-D interval union per strip — O(n² log n),
+/// microseconds at element-tree sizes). Non-finite or degenerate rects are
+/// ignored.
+fn rect_union_area_clipped(rects: &[[f64; 4]], screen_width: f64, screen_height: f64) -> f64 {
+    let clipped: Vec<(f64, f64, f64, f64)> = rects
+        .iter()
+        .filter(|rect| rect.iter().all(|value| value.is_finite()))
+        .map(|&[x, y, width, height]| {
+            (
+                x.max(0.0),
+                (x + width).min(screen_width),
+                y.max(0.0),
+                (y + height).min(screen_height),
+            )
+        })
+        .filter(|(x0, x1, y0, y1)| x1 > x0 && y1 > y0)
+        .collect();
+    if clipped.is_empty() {
+        return 0.0;
+    }
+    let mut xs: Vec<f64> = clipped
+        .iter()
+        .flat_map(|&(x0, x1, _, _)| [x0, x1])
+        .collect();
+    xs.sort_by(f64::total_cmp);
+    xs.dedup();
+    let mut area = 0.0;
+    for strip in xs.windows(2) {
+        let (strip_x0, strip_x1) = (strip[0], strip[1]);
+        if strip_x1 <= strip_x0 {
+            continue;
+        }
+        let mut intervals: Vec<(f64, f64)> = clipped
+            .iter()
+            .filter(|&&(x0, x1, _, _)| x0 <= strip_x0 && x1 >= strip_x1)
+            .map(|&(_, _, y0, y1)| (y0, y1))
+            .collect();
+        intervals.sort_by(|a, b| f64::total_cmp(&a.0, &b.0));
+        let mut covered = 0.0;
+        let mut open_until = f64::NEG_INFINITY;
+        for (y0, y1) in intervals {
+            let y0 = y0.max(open_until);
+            if y1 > y0 {
+                covered += y1 - y0;
+                open_until = y1;
+            }
+            open_until = open_until.max(y1);
+        }
+        area += covered * (strip_x1 - strip_x0);
+    }
+    area
+}
+
 /// How many recent element trees the daemon retains for `?since=` diffs.
 /// An agent diffs against its own previous read, so a handful is plenty; a
 /// miss simply degrades to the full tree.
@@ -5735,11 +5860,15 @@ async fn agent_elements(
     };
     let rows = Arc::new(rows);
     remember_element_snapshot(&state, &snapshot, &rows);
+    // Additive, read-only usability signals over the same rows (visual-fallback
+    // design §1.3): the client decides AX-vs-vision policy; the daemon only
+    // reports. Computed before `screen` is consumed by JSON conversion.
+    let ax_stats = ax_stats(&rows, screen);
     let screen =
         screen.map(|(width, height)| serde_json::json!({"width": width, "height": height}));
     // `?since=` with a still-cached baseline answers with a delta instead of
     // the full tree; anything else (no param, evicted, unknown) stays the
-    // exact pre-diff response shape.
+    // exact pre-diff response shape (plus the additive `ax_stats` key).
     let body = match query
         .since
         .as_deref()
@@ -5753,12 +5882,14 @@ async fn agent_elements(
                 "snapshot": snapshot,
                 "baseline": since,
                 "delta": elements_delta_json(&delta, &rows),
+                "ax_stats": ax_stats,
             })
         }
         None => serde_json::json!({
             "screen": screen,
             "snapshot": snapshot,
             "elements": &*rows,
+            "ax_stats": ax_stats,
         }),
     };
     match serde_json::to_string(&body) {
@@ -6473,6 +6604,111 @@ mod tests {
 
         changed[0].rect[1] = 120.0;
         assert_ne!(snapshot, element_snapshot_id(&changed).unwrap());
+    }
+
+    fn stats_row(kind: &str, label: &str, rect: [f64; 4], depth: u32) -> crate::wda::ElementRow {
+        crate::wda::ElementRow {
+            kind: kind.to_string(),
+            label: label.to_string(),
+            identifier: None,
+            rect,
+            depth,
+            value: None,
+            enabled: None,
+            visible: None,
+            accessible: None,
+            focused: None,
+            placeholder: None,
+        }
+    }
+
+    const STATS_SCREEN: Option<(f64, f64)> = Some((100.0, 200.0));
+
+    #[test]
+    fn ax_stats_empty_tree_reports_zero_targets() {
+        let stats = ax_stats(&[], STATS_SCREEN);
+        assert_eq!(stats.n, 0);
+        assert_eq!(stats.n_interactive, 0);
+        assert_eq!(stats.labeled_frac, 1.0);
+        assert_eq!(stats.coverage, Some(0.0));
+        assert!(stats.container_only);
+        assert_eq!(stats.max_depth, 0);
+    }
+
+    #[test]
+    fn ax_stats_application_node_only_is_container_only_despite_full_coverage() {
+        // The 1-element Mode-A tree seen on games/canvas apps: a single
+        // full-screen Application row. Coverage ≈ 1.0 must not read as healthy
+        // — container_only + zero interactive rows are the gate.
+        let rows = vec![stats_row(
+            "Application",
+            "SomeGame",
+            [0.0, 0.0, 100.0, 200.0],
+            1,
+        )];
+        let stats = ax_stats(&rows, STATS_SCREEN);
+        assert_eq!(stats.n, 1);
+        assert_eq!(stats.n_interactive, 0);
+        assert_eq!(stats.labeled_frac, 1.0);
+        assert_eq!(stats.coverage, Some(1.0));
+        assert!(stats.container_only);
+        assert_eq!(stats.max_depth, 1);
+    }
+
+    #[test]
+    fn ax_stats_healthy_dense_tree() {
+        let rows = vec![
+            stats_row("Window", "", [0.0, 0.0, 100.0, 200.0], 1),
+            stats_row("Button", "返回", [0.0, 0.0, 50.0, 50.0], 3),
+            stats_row("Button", "", [50.0, 0.0, 50.0, 50.0], 3),
+            stats_row("TextField", "搜索", [0.0, 50.0, 100.0, 50.0], 4),
+            stats_row("Cell", "第一条", [0.0, 100.0, 100.0, 50.0], 5),
+            stats_row("StaticText", "标题", [10.0, 10.0, 30.0, 10.0], 4),
+        ];
+        let stats = ax_stats(&rows, STATS_SCREEN);
+        assert_eq!(stats.n, 6);
+        assert_eq!(stats.n_interactive, 4);
+        assert_eq!(stats.labeled_frac, 0.75);
+        // The full-screen Window already covers everything; overlapping child
+        // rects must not double-count past 1.0.
+        assert_eq!(stats.coverage, Some(1.0));
+        assert!(!stats.container_only);
+        assert_eq!(stats.max_depth, 5);
+    }
+
+    #[test]
+    fn ax_stats_coverage_counts_overlap_once_and_clips_to_screen() {
+        let rows = vec![
+            // Two 50×100 rects overlapping in a 25-wide band → union 75×100.
+            stats_row("Button", "a", [0.0, 0.0, 50.0, 100.0], 2),
+            stats_row("Button", "b", [25.0, 0.0, 50.0, 100.0], 2),
+            // Hangs off-screen: only the on-screen 10×200 sliver counts.
+            stats_row("Button", "c", [90.0, -50.0, 60.0, 400.0], 2),
+            // Degenerate and non-finite rects are ignored.
+            stats_row("Button", "d", [10.0, 10.0, 0.0, 40.0], 2),
+            stats_row("Button", "e", [f64::NAN, 0.0, 10.0, 10.0], 2),
+        ];
+        let stats = ax_stats(&rows, STATS_SCREEN);
+        // 75×100 + 10×200 minus their overlap (none: x ranges 0–75 vs 90–100).
+        let expected = (75.0 * 100.0 + 10.0 * 200.0) / (100.0 * 200.0);
+        let coverage = stats.coverage.unwrap();
+        assert!(
+            (coverage - expected).abs() < 1e-9,
+            "coverage {coverage} != {expected}"
+        );
+    }
+
+    #[test]
+    fn ax_stats_without_screen_size_has_null_coverage() {
+        let rows = vec![stats_row("Button", "OK", [0.0, 0.0, 10.0, 10.0], 2)];
+        let stats = ax_stats(&rows, None);
+        assert_eq!(stats.coverage, None);
+        assert_eq!(stats.n_interactive, 1);
+        // And a snapshot id is a function of rows only, so stats can never
+        // perturb it: same rows, with or without stats computed, same token.
+        let before = element_snapshot_id(&rows).unwrap();
+        let _ = ax_stats(&rows, STATS_SCREEN);
+        assert_eq!(before, element_snapshot_id(&rows).unwrap());
     }
 
     fn delta_row(kind: &str, label: &str, y: f64) -> crate::wda::ElementRow {

--- a/crates/server/src/wda.rs
+++ b/crates/server/src/wda.rs
@@ -971,23 +971,27 @@ fn non_empty_string(node: &serde_json::Value, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Element kinds an agent can act on directly. Shared between the tree
+/// flattener (row inclusion) and the `/agent/elements` `ax_stats` block
+/// (`n_interactive`), so the two can never drift apart.
+pub const INTERACTIVE_KINDS: [&str; 11] = [
+    "Button",
+    "Cell",
+    "TextField",
+    "SecureTextField",
+    "SearchField",
+    "Switch",
+    "Slider",
+    "TextView",
+    "PickerWheel",
+    "Picker",
+    "Stepper",
+];
+
 /// Recursively flatten a WDA `/source?format=json` tree, keeping only rows an
 /// agent can act on or learn from: anything with a non-empty label, or an
 /// interactive type. Order is document order (roughly top-to-bottom).
 fn flatten_tree(node: &serde_json::Value, depth: u32, out: &mut Vec<ElementRow>) {
-    const INTERACTIVE: [&str; 11] = [
-        "Button",
-        "Cell",
-        "TextField",
-        "SecureTextField",
-        "SearchField",
-        "Switch",
-        "Slider",
-        "TextView",
-        "PickerWheel",
-        "Picker",
-        "Stepper",
-    ];
     let kind = node
         .get("type")
         .and_then(|t| t.as_str())
@@ -1001,7 +1005,7 @@ fn flatten_tree(node: &serde_json::Value, depth: u32, out: &mut Vec<ElementRow>)
         .or_else(|| node.get("name").and_then(|l| l.as_str()))
         .unwrap_or("")
         .to_string();
-    if !label.is_empty() || INTERACTIVE.contains(&kind.as_str()) {
+    if !label.is_empty() || INTERACTIVE_KINDS.contains(&kind.as_str()) {
         let r = node.get("rect").cloned().unwrap_or_default();
         let g = |k: &str| r.get(k).and_then(|v| v.as_f64()).unwrap_or(0.0);
         // Current value/state (issue #20). WDA reports `value` as a string

--- a/skills/iphone-use/SKILL.md
+++ b/skills/iphone-use/SKILL.md
@@ -70,7 +70,7 @@ and is not a Direct readiness signal.
 | Call | Purpose |
 |---|---|
 | `GET /agent/status` | `{ok, backend, device_state, screen_state, wda, wda_actionable, wda_locked, drivable, released, hint, setup_blocked_on, setup_phase, setup_message, …}` — gate on **`drivable`** |
-| `GET /agent/elements` | **Direct/WDA UI as text**: `{"snapshot":"…","elements":[{kind,label,identifier?,rect,depth,value?,enabled?,visible?,accessible?,focused?,placeholder?},…]}` — prefer this over screenshots. Indexes and snapshot tokens are valid only for this read. Add `?since=<prior snapshot>` to get `{"snapshot":…,"baseline":…,"delta":{added,changed,removed,unchanged}}` instead of the full tree (much cheaper on multi-step flows; unknown baseline falls back to the full tree) |
+| `GET /agent/elements` | **Direct/WDA UI as text**: `{"snapshot":"…","elements":[{kind,label,identifier?,rect,depth,value?,enabled?,visible?,accessible?,focused?,placeholder?},…]}` — prefer this over screenshots. Indexes and snapshot tokens are valid only for this read. Add `?since=<prior snapshot>` to get `{"snapshot":…,"baseline":…,"delta":{added,changed,removed,unchanged}}` instead of the full tree (much cheaper on multi-step flows; unknown baseline falls back to the full tree). Both shapes carry a read-only `ax_stats` usability block — see **Vision fallback** below |
 | `GET /agent/screenshot` | Current phone screen as a device-side PNG; no Mirroring session required |
 | `POST /agent/input` | One action (JSON body, below); requires `X-Phone-Control: 1` |
 | `POST /agent/actions` | One bounded, fail-closed sequence of `action`, `wait_for`, and short `pause` steps; Direct/WDA only; requires `X-Phone-Control: 1` |
@@ -215,6 +215,65 @@ documented or unit-tested action is not automatically a current-device proof:
   replay text, scroll, back, payment, send, or delete actions.
 - A reliable "reset to known state": `shortcut home`, then `shortcut spotlight`
   + `text <app name>` + `key return` to launch any app.
+
+## Vision fallback: when the AX tree is unusable
+
+AX-first is the invariant; vision is a screen-scoped fallback. Two failure
+modes trigger it:
+
+**Mode A — tree too sparse** (games, canvas/WebGL, custom-drawn UI).
+`/agent/elements` succeeds; judge its additive `ax_stats` block
+(`{n, n_interactive, labeled_frac, coverage, container_only, max_depth}`):
+
+- **unusable → go vision**: `n_interactive == 0 && container_only` (e.g. the
+  1-element tree whose only row is the `Application` node — `coverage` ≈ 1.0
+  there is meaningless, never read coverage before those two gates).
+- **degraded → hybrid**: `n_interactive < 3`, or `labeled_frac < 0.3`, or
+  (`coverage < 0.3` and not `container_only`). Use AX for the rows it has,
+  vision for the rest.
+- Otherwise **usable**: stay AX-only. Legitimately sparse screens exist (video
+  player with one "Done" button); low `n` alone is not a trigger — zero usable
+  targets for your current intent is.
+
+**Mode B — reading the tree kills the runner** (KakaoTalk, issue #44: any AX
+hierarchy snapshot crashes on-phone WDA; recovery is a 1–3 min rebuild). The
+signal: `/agent/elements` returns 502 `wda_source_failed` / 504
+`wda_source_timeout` twice on the same foreground app while
+`GET /agent/screenshot` still succeeds. Cache that verdict per app for the
+session — do not re-probe and pay the rebuild again.
+
+**The AX-free loop** (you are the grounding model; no new infra):
+
+1. `GET /agent/screenshot` → reason over the pixels yourself and pick a target.
+2. Act with the **existing** coordinate actions only — `tap` / `longpress` /
+   `swipe`/`scroll` with normalized `[0,1]` coordinates. They dispatch via W3C
+   `/actions` and never resolve the hierarchy. Unsure of the point (< ~0.5
+   confidence)? Send nothing (that is `not_sent`, retry-safe): re-screenshot,
+   crop the region to look closer, or scroll the target into view — then
+   report with a screenshot if still lost.
+3. Verify with a **post-action screenshot** (settle ~300–800 ms), never with an
+   element read. **HARD RULE for Mode-B apps: no `?return=delta`, no
+   element/label taps, no element `wait_for` gates** — each one resolves the
+   tree and takes the device down. The loop must be hermetically AX-free while
+   such an app is foreground. (In Mode A `return=delta` is merely useless — a
+   game's tree doesn't change; screenshot diff is the verifier there too.)
+
+**Degradation ladder** on the existing outcome grammar:
+
+| Situation | Daemon says | Treat as |
+|---|---|---|
+| You abstained (low confidence) | nothing sent | `not_sent`, retry-safe: re-screenshot → crop → scroll → report |
+| Action applied | `outcome:applied` | *dispatched*, not *achieved* — screenshot diff decides |
+| 502/504 after dispatch | `outcome_unknown`, `retry_safe:false` | read a screenshot before any replay (same rule as ever) |
+| `wda_pre_dispatch_failed` / transition | `not_sent`, `retry_safe:true` | retry after status settles |
+| Applied but screen unchanged | `applied` | soft failure: one adjusted retry, then stop and report |
+
+Vision guesses are *weaker* evidence than AX labels: destructive targets
+(send / pay / delete / 2FA) keep their explicit-verification rules regardless
+of channel. Any successful AX read on a new screen flips you back to AX-first,
+and every successful vision sequence should be compiled into a flow per the
+next section — vision is how you discover a flow, not how you run it the
+tenth time.
 
 ## Self-improvement: vision once → script forever
 


### PR DESCRIPTION
Track B of the paradigm work (design: PR #52, `docs/research/2026-09-visual-fallback-driver.md`). v1 keeps the daemon thin: stats in the daemon, policy in the skill, the calling agent is the grounding model.

- Additive read-only `ax_stats` on `GET /agent/elements` (both full and `?since=` delta shapes): element counts, interactive/labeled fractions, screen-coverage (x-sweep interval union, clipped, overlap-once), `container_only`. Snapshot tokens hash rows only — provably unperturbed (dedicated test).
- `skills/iphone-use/SKILL.md`: "Vision fallback" operating procedure — Mode-A thresholds (sparse trees), Mode-B signal (elements 502/504 while screenshot 200s = the #44 KakaoTalk runner-death case), the AX-free loop (screenshot → agent's own vision → existing normalized-coordinate actions), hard ban on `?return=delta`/element locators while a Mode-B app is foreground, degradation ladder mapped to outcome/retry_safe.
- `crates/mcp`: zero diff needed — the elements tool passes the daemon body through verbatim, so `ax_stats` already reaches MCP clients.
- `INTERACTIVE` kind list hoisted to a shared `pub const` (no behavior change).

Tests: 239 server tests green (5 new ax_stats tests incl. stats-invariant snapshot ids); clippy/fmt clean. Independently re-verified by the coordinating session.

**Hardware validation pending (blocking merge):**
- [ ] AX-free loop survives inside KakaoTalk without killing the runner (#44 — reporter-side or local Korean-app repro)
- [ ] Calibrate §1.2 thresholds against real trees (Safari / Home / a known game) using live `ax_stats` output

https://claude.ai/code/session_01VWbwtkurbhQyhoH94t8otU