### PR TITLE
fix(install): 首次安装时 ~/.iphone-use 不存在导致 mktemp 失败

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1449,6 +1449,7 @@ install_pinned_skill() {
     validate_release_commit "$commit" \
         || die "Cannot install an agent skill without an exact release commit."
     raw_url="https://raw.githubusercontent.com/$REPO/$commit/skills/iphone-use/SKILL.md"
+    _ensure_skill_namespace
     SKILL_EXPECTED_DL="$(mktemp "$HOME/.iphone-use/skill-source.XXXXXX")" \
         || die "Could not stage the release-matched agent skill."
     info "Fetching the agent skill from release $ref commit $commit ..."


### PR DESCRIPTION
## 问题

全新机器上首次执行 `curl -fsSL .../install.sh | sh` 必然失败：

```
mktemp: mkstemp failed on /Users/xxx/.iphone-use/skill-source.XXXXXX: No such file or directory
✗ ERROR: Could not stage the release-matched agent skill.
```

## 根因

`install_pinned_skill`（install.sh:1452）在调用 `_install_verified_skill` **之前** 就执行 `mktemp "$HOME/.iphone-use/skill-source.XXXXXX"`，而 `~/.iphone-use` 目录要等事务内部的 `_snapshot_skill_state → _ensure_skill_namespace` 才会被创建。首次安装时该目录不存在，`mktemp` 直接报错退出。

复现：`rm -rf ~/.iphone-use` 后运行官方安装命令。

## 修复

在 `mktemp` 前调用幂等的 `_ensure_skill_namespace`：

- 目录不存在时以 `700` 创建，存在时沿用既有的 symlink 拒绝 / uid 属主校验，与脚本整体安全姿态一致；
- 后续 `_snapshot_skill_state` 中的重复调用是幂等 no-op，行为不变；
- 单行改动，不引入新逻辑。

## 验证

- `bash -n install.sh` 语法通过
- `scripts/test-install-release-transaction.sh` 全部 21 个用例通过（含「failed fresh install restores the original absent state」）
- 注：pinned bootstrap 路径只在 `curl | sh` 拉取已发布 release 时触发，无法在本 PR 合并前端到端复验；但修复所依赖的 `_ensure_skill_namespace` 已被现有事务测试覆盖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Installation now ensures required skill directories exist and are owned by the current user before downloading and staging the skill package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->